### PR TITLE
Cleaned up auth server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = [
+    "auth_server",
+    "databases/wrath-auth-db",
+    "databases/wrath-realm-db",
+    "world_server"
+]

--- a/auth_server/Cargo.toml
+++ b/auth_server/Cargo.toml
@@ -7,14 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = {version="*", features=["attributes"] }
+wow_srp = { git = "https://github.com/WeaponMan/wow_srp.git", rev = "66bcf26369dca4cb25556e2e22ea41639e7357ef" }
+byteorder = { version = '1' }
+async-std = { version = "*", features = ["attributes"] }
 anyhow = { version = "*" }
-podio = { version = "*" } 
-dotenv = { version="*" }
-sha-1 = { version = "*" }
-rand = { version = "0.7" } 
-num-bigint = { version = "0.3", features=["rand"] } 
-num-traits = { version = "0.2.12" } 
+dotenv = { version = "*" }
+hex = { version = "0.4" }
 wrath-auth-db = { path = "../databases/wrath-auth-db" }
-tracing = {version="0.1"}
-tracing-subscriber = {version = "0.2" }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.2" }

--- a/auth_server/Cargo.toml
+++ b/auth_server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wow_srp = { git = "https://github.com/WeaponMan/wow_srp.git", rev = "66bcf26369dca4cb25556e2e22ea41639e7357ef" }
+wow_srp = { git = "https://github.com/WeaponMan/wow_srp.git", rev = "8e38d0ece4f8ebe2fff37e464b921fdf543992b8" }
 byteorder = { version = '1' }
 async-std = { version = "*", features = ["attributes"] }
 anyhow = { version = "*" }

--- a/auth_server/src/auth.rs
+++ b/auth_server/src/auth.rs
@@ -3,279 +3,161 @@ use super::prelude::*;
 use anyhow::*;
 use async_std::net::TcpStream;
 use async_std::prelude::*;
-use num_bigint::BigUint;
-use num_bigint::RandBigInt;
-use num_traits::Zero;
-use podio::{LittleEndian, ReadPodExt, WritePodExt};
-use sha1::Digest;
-use std::io::Write;
+use std::io::Cursor;
+use wow_srp::normalized_string::NormalizedString;
+use wow_srp::server::{SrpProof, SrpServer, SrpVerifier};
+use wow_srp::{PublicKey, GENERATOR, LARGE_SAFE_PRIME_LITTLE_ENDIAN, PASSWORD_VERIFIER_LENGTH, PROOF_LENGTH, PUBLIC_KEY_LENGTH, SALT_LENGTH};
 use wrath_auth_db::AuthDatabase;
 
-#[derive(Default, Clone)]
-pub struct LoginNumbers {
-    pub n: BigUint,
-    pub g: BigUint,
-    pub b: BigUint,
-    pub bb: BigUint,
-    pub v: BigUint,
-    pub s: BigUint,
+use crate::packet::client::{LogonChallenge, LogonProof};
+use crate::packet::server::{LogonChallengeBody, LogonProofBody, ServerPacket};
+use crate::packet::PacketWriter;
+
+pub struct ServerChallengeProof {
+    pub srp_proof: SrpProof,
     pub username: String,
 }
 
-pub async fn handle_logon_challenge(stream: &mut TcpStream, buf: &[u8], auth_database: &std::sync::Arc<AuthDatabase>) -> Result<LoginNumbers> {
-    use num_traits::cast::FromPrimitive;
-
-    let mut logindata: LoginNumbers = LoginNumbers::default();
-
-    let mut reader = std::io::Cursor::new(buf);
-    let _cmd = reader.read_u8()?;
-    let _error = reader.read_u8()?;
-    let _size = reader.read_u16::<LittleEndian>()?;
-    let _gamename = reader.read_exact(4)?;
-    let version1 = reader.read_u8()?;
-    let version2 = reader.read_u8()?;
-    let version3 = reader.read_u8()?;
-    let build = reader.read_u16::<LittleEndian>()?;
-    let _platform = reader.read_u32::<LittleEndian>()?;
-    let _os = reader.read_u32::<LittleEndian>()?;
-    let _country = reader.read_u32::<LittleEndian>()?;
-    let _timezone_bias = reader.read_u32::<LittleEndian>()?;
-    let ip = reader.read_exact(4)?;
-    let username_length = reader.read_u8()? as usize;
-    let username_bytes = reader.read_exact(username_length)?;
-    let username = std::str::from_utf8(&username_bytes)?;
-    logindata.username = username.to_string();
-
-    info!(
-        "Logon challenge for user {} on ip {}.{}.{}.{}, version {}.{}.{}:{}",
-        username, ip[0], ip[1], ip[2], ip[3], version1, version2, version3, build
-    );
-
-    let account = (*auth_database).get_account_by_username(&username).await;
-
-    if account.is_err() {
-        reject_login(stream, constants::AuthResult::FailUnknownAccount).await?;
-        return Err(anyhow!("Username not found in database"));
-    }
-
-    let account = account?;
-
-    if account.banned != 0 {
-        reject_login(stream, constants::AuthResult::FailBanned).await?;
-        return Err(anyhow!("Account was banned, refusing login"));
-    }
-
-    logindata.g = BigUint::from_u64(7u64).unwrap();
-    logindata.n =
-        BigUint::parse_bytes(b"894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7", 16).ok_or_else(|| anyhow!("Failed to parse N"))?;
-    let n_bytes = logindata.n.to_bytes_le();
-    assert!(n_bytes.len() == 32);
-
-    if account.v.is_empty() || account.s.is_empty() {
-        let (v, s) = generate_vs(&account.sha_pass_hash, &logindata.g, &logindata.n).await?;
-        (*auth_database)
-            .set_account_v_s(account.id, &v.to_str_radix(16), &s.to_str_radix(16))
-            .await?;
-
-        logindata.v = v;
-        logindata.s = s;
-
-        //trace!("v={}", logindata.v.to_str_radix(16));
-        //trace!("s={}", logindata.s.to_str_radix(16));
-    } else {
-        logindata.v = BigUint::parse_bytes(account.v.as_bytes(), 16).ok_or_else(|| anyhow!("Failed to parse v from database"))?;
-        logindata.s = BigUint::parse_bytes(account.s.as_bytes(), 16).ok_or_else(|| anyhow!("Failed to parse s from database"))?;
-    }
-    let s_bytes = logindata.s.to_bytes_le();
-    assert!(s_bytes.len() == 32);
-
-    logindata.b = rand::thread_rng().gen_biguint(19 * 8);
-    //logindata.b = BigUint::from_str_radix("6dd94824b210c7b205974f9f53e9539ed459991932b0ca50f6a1bdc839c5c486", 16)?;
-    //trace!("b={}", logindata.b.to_str_radix(16));
-
-    let gmod = logindata.g.modpow(&logindata.b, &logindata.n);
-    logindata.bb = ((&logindata.v * 3u32) + gmod) % &logindata.n;
-    //trace!("B={}", logindata.bb.to_str_radix(16));
-    let bb_bytes = logindata.bb.to_bytes_le();
-    assert!(bb_bytes.len() == 32);
-    //bb_bytes.resize(32, 0);
-
-    //let unk : BigUint = rand::thread_rng().gen_biguint(16 * 8);
-    //let unk = BigUint::from_str_radix("383855f209cf4e2267e3fc317cf6fb6f", 16)?;
-    //trace!("unk={}", unk.to_str_radix(16));
-
-    //let unk_bytes = unk.to_bytes_le();
-    let unk_bytes = [0u8; 16];
-    assert!(unk_bytes.len() == 16);
-
-    let return_buf: Vec<u8> = Vec::new();
-    let mut writer = std::io::Cursor::new(return_buf);
-    writer.write_u8(0)?; //AUTH_LOGON_CHALLENGE
-    writer.write_u8(0)?;
-    writer.write_u8(constants::AuthResult::Success as u8)?;
-    writer.write(&bb_bytes.as_slice())?;
-    writer.write_u8(1)?;
-    writer.write_u8(7)?; // value of g in one byte
-    writer.write_u8(32)?;
-    writer.write(n_bytes.as_slice())?;
-    writer.write(s_bytes.as_slice())?;
-    writer.write(&unk_bytes)?;
-    writer.write_u8(0)?;
-    stream.write(&writer.into_inner()).await?;
-    stream.flush().await?;
-
-    Ok(logindata)
+pub struct ServerLogOnProof {
+    pub srp_server: SrpServer,
+    pub username: String,
 }
 
-pub async fn generate_vs(hashed_password: &String, g: &BigUint, n: &BigUint) -> Result<(BigUint, BigUint)> {
-    let s: BigUint = rand::thread_rng().gen_biguint(256);
-    //let s = BigUint::from_str_radix("16db0802870c05966e6ff6f80dd13f689c0067ce77ae233c15f86f316d919885", 16)?;
-
-    let pw = BigUint::parse_bytes(hashed_password.as_bytes(), 16).unwrap();
-
-    let mut hasher = sha1::Sha1::new();
-    hasher.update(s.to_bytes_le());
-    hasher.update(pw.to_bytes_be());
-    let hashed = hasher.finalize();
-    let x: BigUint = BigUint::from_bytes_le(hashed.as_slice());
-
-    let v: BigUint = g.modpow(&x, n);
-
-    Ok((v, s))
-}
-
-async fn reject_login(stream: &mut TcpStream, reason: constants::AuthResult) -> Result<()> {
-    let return_buf: Vec<u8> = Vec::new();
-    let mut writer = std::io::Cursor::new(return_buf);
-    writer.write_u8(0u8)?; //AUTH_LOGON_CHALLENGE
-    writer.write_u8(0u8)?;
-    writer.write_u8(reason as u8)?;
-    stream.write(&writer.into_inner()).await?;
-    stream.flush().await?;
-    Ok(())
-}
-
-pub async fn handle_logon_proof(
+//TODO: check if already logged in
+pub async fn handle_logon_proof_srp(
     stream: &mut TcpStream,
-    buf: &[u8],
-    logindata: &LoginNumbers,
-    auth_database: &std::sync::Arc<AuthDatabase>,
-) -> Result<()> {
-    info!("Received login proof");
-    if logindata.n.is_zero() {
-        return Err(anyhow!(
-            "Trying to handle login proof but no numbers have been generated from the challenge. Hacking?"
-        ));
+    logon_proof: LogonProof,
+    proof: ServerChallengeProof,
+    auth_database: std::sync::Arc<AuthDatabase>,
+) -> Result<ServerLogOnProof> {
+    let buf = Vec::new();
+    let mut cursor = Cursor::new(buf);
+
+    let mut client_public_key = [0u8; PUBLIC_KEY_LENGTH as usize];
+    client_public_key.clone_from_slice(&logon_proof.public_key[..PUBLIC_KEY_LENGTH as usize]);
+    let client_public_key = match PublicKey::from_le_bytes(&client_public_key) {
+        Ok(key) => key,
+        Err(_) => {
+            ServerPacket::LogonProof {
+                result: AuthResult::FailIncorrectPassword as u8,
+                result_padding: Some(0),
+                body: None,
+            }
+            .write_packet(&mut cursor)?;
+            stream.write(&cursor.get_ref()).await?;
+            stream.flush().await?;
+            return Err(anyhow!("Invalid client public key. This is likely a result of malformed packets."));
+        }
+    };
+    let username = proof.username;
+    let mut client_proof = [0u8; PROOF_LENGTH as usize];
+    client_proof.clone_from_slice(&logon_proof.proof[..PROOF_LENGTH as usize]);
+    let (s, server_proof) = match proof.srp_proof.into_server(client_public_key, client_proof) {
+        Ok(s) => s,
+        Err(e) => {
+            ServerPacket::LogonProof {
+                result: AuthResult::FailIncorrectPassword as u8,
+                result_padding: Some(0),
+                body: None,
+            }
+            .write_packet(&mut cursor)?;
+            stream.write(&cursor.get_ref()).await?;
+            stream.flush().await?;
+            return Err(anyhow!(e));
+        }
+    };
+
+    auth_database.set_account_sessionkey(&username, &hex::encode(s.session_key())).await?;
+
+    ServerPacket::LogonProof {
+        result: AuthResult::Success as u8,
+        result_padding: None,
+        body: Some(LogonProofBody {
+            proof: server_proof.to_vec(),
+            account_flag: 0,
+            hardware_survey_id: 0,
+            unknown_flags: 0,
+        }),
     }
-
-    let mut reader = std::io::Cursor::new(buf);
-    let _cmd = reader.read_u8()?;
-    let a_bytes = reader.read_exact(32)?;
-    let m_one_bytes = reader.read_exact(20)?;
-    let _crc_hash_bytes = reader.read_exact(20)?;
-    let _number_of_keys = reader.read_u8()?;
-    let _security_flags = reader.read_u8()?;
-
-    let a: BigUint = BigUint::from_bytes_le(&a_bytes);
-    //let a = BigUint::from_str_radix("3e7738d6735bac8dfa29a261635bc500cb396a1115a7cf8c62ddb75b045e89ec", 16)?;
-    //let a_bytes = a.to_bytes_le();
-    //trace!("A={}", a.to_str_radix(16));
-    if (&a % &logindata.n).is_zero() {
-        return Err(anyhow!("a%N cannot be zero according to SRP protocol"));
-    }
-
-    let mut hasher = sha1::Sha1::new();
-    hasher.update(&a.to_bytes_le());
-    hasher.update(&logindata.bb.to_bytes_le());
-    let hashed = hasher.finalize_reset();
-    let u = BigUint::from_bytes_le(hashed.as_slice());
-    //trace!("u={}", u.to_str_radix(16));
-    let s = (&a * (logindata.v.modpow(&u, &logindata.n))).modpow(&logindata.b, &logindata.n);
-    //trace!("S={}", s.to_str_radix(16));
-    let s_bytes = s.to_bytes_le();
-    assert!(s_bytes.len() == 32);
-
-    let t1 = &mut [0; 16];
-    for i in 0..16 {
-        t1[i] = s_bytes[i * 2];
-    }
-
-    hasher.update(&t1);
-    let pre_vk = hasher.finalize_reset();
-    assert!(pre_vk.len() == 20);
-
-    let vk = &mut [0; 40];
-    for i in 0..20 {
-        vk[i * 2] = pre_vk[i];
-    }
-
-    for i in 0..16 {
-        t1[i] = s_bytes[i * 2 + 1];
-    }
-    assert!(t1.len() == 16);
-
-    hasher.update(&t1);
-    let pre_vk2 = hasher.finalize_reset();
-
-    for i in 0..20 {
-        vk[i * 2 + 1] = pre_vk2[i];
-    }
-
-    let k = BigUint::from_bytes_le(vk);
-    //trace!("k={}", k.to_str_radix(16));
-
-    hasher.update(logindata.n.to_bytes_le());
-    let mut n_hash = hasher.finalize_reset();
-    assert!(n_hash.len() == 20);
-
-    hasher.update(logindata.g.to_bytes_le());
-    assert!(logindata.g.to_bytes_le().len() == 1);
-    let g_hash = hasher.finalize_reset();
-
-    for i in 0..20 {
-        n_hash[i] ^= g_hash[i];
-    }
-
-    let t3 = BigUint::from_bytes_le(&n_hash);
-    hasher.update(&logindata.username);
-    let t4 = hasher.finalize_reset();
-    assert!(t4.len() == 20);
-
-    hasher.update(&t3.to_bytes_le());
-    hasher.update(&t4);
-    hasher.update(&logindata.s.to_bytes_le());
-    hasher.update(&a_bytes);
-    hasher.update(&logindata.bb.to_bytes_le());
-    hasher.update(&k.to_bytes_le());
-    let m_bytes = hasher.finalize_reset();
-    let m = BigUint::from_bytes_le(&m_bytes);
-    let _m1 = BigUint::from_bytes_le(&m_one_bytes);
-
-    hasher.update(&a_bytes);
-    hasher.update(&m_bytes);
-    hasher.update(&k.to_bytes_le());
-    let m2_bytes = hasher.finalize_reset();
-    let m2 = BigUint::from_bytes_be(&m2_bytes);
-
-    //trace!("m : {}\nm1: {}\nm2: {}", m.to_str_radix(16), m1.to_str_radix(16), m2.to_str_radix(16));
-    if m.to_bytes_le() != m_one_bytes {
-        stream.write(&[1, constants::AuthResult::FailNoAccess as u8, 3, 0]).await?;
-        stream.flush().await?;
-        return Err(anyhow!("Wrong password"));
-    }
-
-    (*auth_database).set_account_sessionkey(&logindata.username, &k.to_str_radix(16)).await?;
-
-    let write_buf = Vec::<u8>::new();
-    let mut writer = std::io::Cursor::new(write_buf);
-    writer.write_u8(1)?; //AUTH_LOGON_PROOF
-    writer.write_u8(0)?; //Proof success
-    writer.write(&m2.to_bytes_be())?;
-    writer.write_u32::<LittleEndian>(0u32)?;
-    writer.write_u32::<LittleEndian>(0u32)?;
-    writer.write_u16::<LittleEndian>(0u16)?;
-    stream.write(&writer.into_inner()).await?;
+    .write_packet(&mut cursor)?;
+    stream.write(&cursor.get_ref()).await?;
     stream.flush().await?;
 
-    Ok(())
+    Ok(ServerLogOnProof { srp_server: s, username })
+}
+
+//TODO: check if already logged in
+pub async fn handle_logon_challenge_srp(
+    stream: &mut TcpStream,
+    challenge: LogonChallenge,
+    auth_database: std::sync::Arc<AuthDatabase>,
+) -> Result<ServerChallengeProof> {
+    let buf = Vec::new();
+    let mut cursor = Cursor::new(buf);
+    let account = match auth_database.get_account_by_username(&challenge.username).await {
+        Ok(acc) if acc.banned != 0 => {
+            let buf = Vec::new();
+            let mut cursor = Cursor::new(buf);
+            ServerPacket::LogonChallenge {
+                result: constants::AuthResult::FailBanned as u8,
+                body: None,
+            }
+            .write_packet(&mut cursor)?;
+            stream.write(&cursor.get_ref()).await?;
+            stream.flush().await?;
+            return Err(anyhow!("Account was banned, refusing login"));
+        }
+        Ok(acc) => acc,
+        Err(_) => {
+            ServerPacket::LogonChallenge {
+                result: constants::AuthResult::FailUnknownAccount as u8,
+                body: None,
+            }
+            .write_packet(&mut cursor)?;
+            stream.write(&cursor.get_ref()).await?;
+            stream.flush().await?;
+            return Err(anyhow!("Username not found in database"));
+        }
+    };
+
+    let username = NormalizedString::new(&account.username)?;
+    let s = if account.v.is_empty() || account.s.is_empty() {
+        let g = SrpVerifier::from_username_and_password_hashed(username, &account.sha_pass_hash)?;
+        let v = g.password_verifier();
+        let s = g.salt();
+        auth_database.set_account_v_s(account.id, &hex::encode(v), &hex::encode(s)).await?;
+        g
+    } else {
+        //FIXME(wmxd): maybe this section can be done simpler
+        let mut password_verifier: [u8; PASSWORD_VERIFIER_LENGTH as usize] = Default::default();
+        let mut salt: [u8; SALT_LENGTH as usize] = Default::default();
+        let big_v = hex::decode(account.v.as_bytes())?;
+        let big_s = hex::decode(account.s.as_bytes())?;
+        password_verifier.copy_from_slice(&big_v);
+        salt.copy_from_slice(&big_s);
+        SrpVerifier::from_database_values(username, password_verifier, salt)
+    };
+
+    let proof = s.into_proof();
+    ServerPacket::LogonChallenge {
+        result: constants::AuthResult::Success as u8,
+        body: Some(LogonChallengeBody {
+            public_key: proof.server_public_key().to_vec(),
+            generator: vec![GENERATOR],
+            large_safe_prime: LARGE_SAFE_PRIME_LITTLE_ENDIAN.to_vec(),
+            salt: proof.salt().to_vec(),
+            crc_salt: vec![
+                0xBA, 0xA3, 0x1E, 0x99, 0xA0, 0x0B, 0x21, 0x57, 0xFC, 0x37, 0x3F, 0xB3, 0x69, 0xCD, 0xD2, 0xF1,
+            ],
+            // https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/authserver/Server/AuthSession.cpp:117
+            security_flags: 0,
+        }),
+    }
+    .write_packet(&mut cursor)?;
+    stream.write(&cursor.get_ref()).await?;
+    stream.flush().await?;
+    Ok(ServerChallengeProof {
+        srp_proof: proof,
+        username: account.username,
+    })
 }

--- a/auth_server/src/packet/client.rs
+++ b/auth_server/src/packet/client.rs
@@ -1,0 +1,88 @@
+use crate::packet::consts::*;
+use crate::packet::utils::{read_sized_bytes, read_sized_string, read_sized_string_with_len_field_u8};
+use crate::packet::PacketReader;
+use anyhow::Result;
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Read;
+
+// This could use some derive marcos just to skip the impl part,
+// but its magic to me how to write that derive marco
+
+//FIXME(wmxd): dont use Vec and String, use &[u8] and &str with lifetimes
+#[derive(Debug)]
+pub struct LogonChallenge {
+    pub protocol_version: u8,
+    pub size: u16,
+    pub game_name: String,
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+    pub build: u16,
+    pub platform: String,
+    pub os: String,
+    pub locale: String,
+    pub timezone_bias: u32,
+    pub ip: Vec<u8>,
+    pub username: String,
+    pub reconnect: bool,
+}
+
+#[derive(Debug)]
+pub struct LogonProof {
+    pub public_key: Vec<u8>,
+    pub proof: Vec<u8>,
+    pub crc_hash: Vec<u8>,
+    pub number_of_keys: u8,
+    pub security_flags: u8,
+    pub reconnect: bool,
+}
+
+#[derive(Debug)]
+pub enum ClientPacket {
+    LogonChallenge(LogonChallenge),
+    LogonProof(LogonProof),
+    RealmListRequest,
+    NotImplemented,
+}
+
+impl PacketReader for ClientPacket {
+    fn read_packet<R>(reader: &mut R) -> Result<Self>
+    where
+        R: Read,
+    {
+        let cmd = reader.read_u8()?;
+        let packet = match cmd {
+            CMD_AUTH_LOGON_CHALLENGE | CMD_AUTH_RECONNECT_CHALLENGE => ClientPacket::LogonChallenge(LogonChallenge {
+                protocol_version: reader.read_u8()?,
+                size: reader.read_u16::<LittleEndian>()?,
+                game_name: read_sized_string(reader, 4)?,
+                major: reader.read_u8()?,
+                minor: reader.read_u8()?,
+                patch: reader.read_u8()?,
+                build: reader.read_u16::<LittleEndian>()?,
+                platform: read_sized_string(reader, 4)?,
+                os: read_sized_string(reader, 4)?,
+                locale: read_sized_string(reader, 4)?,
+                timezone_bias: reader.read_u32::<LittleEndian>()?,
+                ip: read_sized_bytes(reader, 4)?,
+                username: read_sized_string_with_len_field_u8(reader)?,
+                reconnect: cmd == CMD_AUTH_RECONNECT_CHALLENGE,
+            }),
+            CMD_AUTH_LOGON_PROOF | CMD_AUTH_RECONNECT_PROOF => ClientPacket::LogonProof(LogonProof {
+                public_key: read_sized_bytes(reader, 32)?,
+                proof: read_sized_bytes(reader, 20)?,
+                crc_hash: read_sized_bytes(reader, 20)?,
+                number_of_keys: reader.read_u8()?,
+                security_flags: if cmd != CMD_AUTH_RECONNECT_PROOF { reader.read_u8()? } else { 0 },
+                reconnect: cmd == CMD_AUTH_RECONNECT_PROOF,
+            }),
+            CMD_REALM_LIST => {
+                let _padding = reader.read_u32::<LittleEndian>()?;
+                ClientPacket::RealmListRequest
+            }
+            _ => ClientPacket::NotImplemented,
+        };
+
+        Ok(packet)
+    }
+}

--- a/auth_server/src/packet/consts.rs
+++ b/auth_server/src/packet/consts.rs
@@ -1,0 +1,5 @@
+pub const CMD_AUTH_LOGON_CHALLENGE: u8 = 0x00;
+pub const CMD_AUTH_LOGON_PROOF: u8 = 0x01;
+pub const CMD_AUTH_RECONNECT_CHALLENGE: u8 = 0x02;
+pub const CMD_AUTH_RECONNECT_PROOF: u8 = 0x03;
+pub const CMD_REALM_LIST: u8 = 0x10;

--- a/auth_server/src/packet/mod.rs
+++ b/auth_server/src/packet/mod.rs
@@ -1,0 +1,20 @@
+pub(crate) mod client;
+pub(crate) mod server;
+
+mod consts;
+mod utils;
+
+use anyhow::Result;
+use std::io::{Read, Write};
+
+pub(crate) trait PacketReader: Sized {
+    fn read_packet<R>(reader: &mut R) -> Result<Self>
+    where
+        R: Read;
+}
+
+pub(crate) trait PacketWriter: Sized {
+    fn write_packet<W>(&self, writer: &mut W) -> Result<()>
+    where
+        W: Write;
+}

--- a/auth_server/src/packet/server.rs
+++ b/auth_server/src/packet/server.rs
@@ -1,0 +1,150 @@
+use crate::packet::consts::{CMD_AUTH_LOGON_CHALLENGE, CMD_AUTH_LOGON_PROOF, CMD_REALM_LIST};
+use crate::packet::PacketWriter;
+use crate::prelude::RealmFlags;
+use anyhow::Result;
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{Cursor, Write};
+use wrath_auth_db::AuthDatabase;
+
+#[derive(Debug)]
+pub enum ServerPacket {
+    LogonChallenge {
+        result: u8,
+        body: Option<LogonChallengeBody>,
+    },
+    LogonProof {
+        result: u8,
+        result_padding: Option<u16>,
+        body: Option<LogonProofBody>,
+    },
+    RealmListRequest(Vec<Realm>),
+}
+
+#[derive(Debug)]
+pub struct LogonChallengeBody {
+    pub public_key: Vec<u8>,
+    pub generator: Vec<u8>,
+    pub large_safe_prime: Vec<u8>,
+    pub salt: Vec<u8>,
+    pub crc_salt: Vec<u8>,
+    pub security_flags: u8,
+}
+
+#[derive(Debug)]
+pub struct LogonProofBody {
+    pub proof: Vec<u8>,
+    pub account_flag: u32,
+    pub hardware_survey_id: u32,
+    pub unknown_flags: u16,
+}
+
+#[derive(Debug)]
+pub struct Realm {
+    pub realm_type: u8,
+    pub locked: u8,
+    pub flags: u8,
+    pub name: String,
+    pub address: String,
+    pub population: f32,
+    pub number_of_chars: u8,
+    pub realm_category: u8,
+    pub realm_id: u8,
+}
+
+impl Realm {
+    pub async fn from_db(auth_database: std::sync::Arc<AuthDatabase>, account_id: u32) -> Result<Vec<Self>> {
+        //TODO(wmxd): it will be good idea to cache the database stuff
+        //TODO(wmxd): for now it will be better select realms and number_of_chars in one database trip (eg: left join)
+        let db_realms = auth_database.get_all_realms().await?;
+        let mut realms = Vec::with_capacity(db_realms.len());
+        for realm in db_realms {
+            let num_characters = auth_database.get_num_characters_on_realm(account_id, realm.id).await?;
+            let mut realm_flags = realm.flags as u8;
+            if realm.online == 0 {
+                realm_flags |= RealmFlags::Offline as u8;
+            }
+
+            realms.push(Realm {
+                realm_type: realm.realm_type,
+                locked: 0,
+                flags: realm_flags,
+                name: realm.name,
+                address: realm.ip,
+                population: realm.population,
+                number_of_chars: num_characters,
+                realm_category: realm.timezone,
+                realm_id: 0,
+            });
+        }
+
+        Ok(realms)
+    }
+}
+
+impl PacketWriter for ServerPacket {
+    fn write_packet<W>(&self, writer: &mut W) -> Result<()>
+    where
+        W: Write,
+    {
+        match self {
+            ServerPacket::LogonChallenge { result, body } => {
+                writer.write_u8(CMD_AUTH_LOGON_CHALLENGE)?;
+                writer.write_u8(0)?; // protocol version
+                writer.write_u8(*result)?;
+                if let Some(body) = body {
+                    writer.write(&body.public_key)?;
+                    writer.write_u8(body.generator.len() as u8)?;
+                    writer.write(&body.generator)?;
+                    writer.write_u8(body.large_safe_prime.len() as u8)?;
+                    writer.write(&body.large_safe_prime)?;
+                    writer.write(&body.salt)?;
+                    writer.write(&body.crc_salt)?;
+                    writer.write_u8(body.security_flags)?;
+                }
+            }
+            ServerPacket::LogonProof {
+                result,
+                result_padding,
+                body,
+            } => {
+                writer.write_u8(CMD_AUTH_LOGON_PROOF)?;
+                writer.write_u8(*result)?;
+                if let Some(result_padding) = *result_padding {
+                    writer.write_u16::<LittleEndian>(result_padding)?;
+                }
+
+                if let Some(body) = body {
+                    writer.write(&body.proof)?;
+                    writer.write_u32::<LittleEndian>(body.account_flag)?;
+                    writer.write_u32::<LittleEndian>(body.hardware_survey_id)?;
+                    writer.write_u16::<LittleEndian>(body.unknown_flags)?;
+                }
+            }
+            ServerPacket::RealmListRequest(realms) => {
+                let buf = Vec::new();
+                let mut cursor = Cursor::new(buf);
+                cursor.write_u32::<LittleEndian>(0)?; // Some kind of padding
+                cursor.write_u16::<LittleEndian>(realms.len() as u16)?;
+                for realm in realms {
+                    cursor.write_u8(realm.realm_type)?;
+                    cursor.write_u8(realm.locked)?;
+                    cursor.write_u8(realm.flags)?;
+                    cursor.write(realm.name.as_bytes())?;
+                    cursor.write_u8(0)?; //string terminator
+                    cursor.write(realm.address.as_bytes())?;
+                    cursor.write_u8(0)?; //string terminator
+                    cursor.write_f32::<LittleEndian>(realm.population)?;
+                    cursor.write_u8(realm.number_of_chars)?;
+                    cursor.write_u8(realm.realm_category as u8)?;
+                    cursor.write_u8(realm.realm_id)?;
+                }
+                cursor.write_u16::<LittleEndian>(0)?; // Some kind of padding
+
+                writer.write_u8(CMD_REALM_LIST)?;
+                writer.write_u16::<LittleEndian>(cursor.get_ref().len() as u16)?;
+                writer.write(&cursor.get_ref())?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/auth_server/src/packet/utils.rs
+++ b/auth_server/src/packet/utils.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use byteorder::ReadBytesExt;
+
+#[inline]
+pub fn read_sized_string<R: std::io::Read>(reader: &mut R, size: usize) -> Result<String> {
+    let mut bytes = vec![0; size];
+    reader.read_exact(&mut bytes)?;
+    let str = std::str::from_utf8(&bytes)?;
+    Ok(str.to_string())
+}
+
+#[inline]
+pub fn read_sized_bytes<R: std::io::Read>(reader: &mut R, size: usize) -> Result<Vec<u8>> {
+    let mut bytes = vec![0; size];
+    reader.read_exact(&mut bytes)?;
+    Ok(bytes)
+}
+
+#[inline]
+pub fn read_sized_string_with_len_field_u8<R: std::io::Read>(reader: &mut R) -> Result<String> {
+    let length = reader.read_u8()? as usize;
+    let mut bytes = vec![0; length];
+    reader.read_exact(&mut bytes)?;
+    let str = std::str::from_utf8(&bytes)?;
+    Ok(str.to_string())
+}

--- a/databases/wrath-auth-db/migrations/20200830073445_setup.sql
+++ b/databases/wrath-auth-db/migrations/20200830073445_setup.sql
@@ -9,7 +9,7 @@ CREATE TABLE `accounts`
   `token_key` varchar(100) NOT NULL DEFAULT '',
   `banned` tinyint(1) unsigned zerofill NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 INSERT INTO accounts VALUES
 (NULL, 'test', "3d0d99423e31fcc67a6745ec89d70d700344bc76", '', '', '', '', 0),
@@ -25,7 +25,7 @@ CREATE TABLE `realms` (
   `timezone` tinyint(1) unsigned zerofill NOT NULL DEFAULT '1',
   `online` tinyint(1) unsigned zerofill NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 INSERT INTO realms VALUES
 (NULL, 'testrealm', 0, 0, "127.0.0.1:8085", 0.0, 1, 0);
@@ -38,7 +38,7 @@ CREATE TABLE `account_data` (
 	`data` longblob,
 	KEY `FK_ACCOUNT_DATA_ACCOUNT` (`account_id`),
 	CONSTRAINT `FK_ACCOUNT` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `realm_characters` (
 	`account_id` int unsigned NOT NULL DEFAULT '0',


### PR DESCRIPTION
1. Added root Cargo.toml with workspace, its just better to have open workspace then each project in seperate window
2. Changed collate on auth tables, because MariaDb doesnt have this collate 
3. Rewritten all the sqlx marcos to normal methods in wrath-auth-db, because marcos connect at build time to database, takes time and you cant build without existing database
3. Reworked packets into structs and traits, 
4. Reworked packet handlers, added wow_srp instead of manualy doing that work, I will have to create pr to it, because they expect plaintext password, but we got only sha1("username:password") in db

I do hope, you didnt abaddon this project, if not I will tackle the reconnects in auth server next.
If you need to slip into seperate PR let me know.



