### PR TITLE
Accounts refactor

### DIFF
--- a/auth_server/src/console_input.rs
+++ b/auth_server/src/console_input.rs
@@ -33,10 +33,14 @@ pub async fn process_console_commands(auth_db: std::sync::Arc<AuthDatabase>) -> 
 }
 
 async fn handle_command(cmd: WrathConsoleCommand, auth_db: std::sync::Arc<AuthDatabase>) -> Result<()> {
-    match cmd {
-        WrathConsoleCommand::CreateAccount(username, password) => handle_create_account(&username, &password, &auth_db).await?,
-        WrathConsoleCommand::Ban(username) => handle_ban(&username, &auth_db).await?,
-        WrathConsoleCommand::Unban(username) => handle_unban(&username, &auth_db).await?,
+    let result = match cmd {
+        WrathConsoleCommand::CreateAccount(username, password) => handle_create_account(&username, &password, &auth_db).await,
+        WrathConsoleCommand::Ban(username) => handle_ban(&username, &auth_db).await,
+        WrathConsoleCommand::Unban(username) => handle_unban(&username, &auth_db).await,
+    };
+
+    if let Err(e) = result {
+        warn!("Error: {}", e);
     }
     Ok(())
 }

--- a/auth_server/src/console_input.rs
+++ b/auth_server/src/console_input.rs
@@ -9,6 +9,8 @@ use wrath_auth_db::AuthDatabase;
 #[derive(Debug, PartialEq, Eq, Parsable)]
 enum WrathConsoleCommand {
     CreateAccount(String, String),
+    Ban(String),
+    Unban(String),
 }
 
 pub async fn process_console_commands(auth_db: std::sync::Arc<AuthDatabase>) -> Result<()> {
@@ -33,6 +35,8 @@ pub async fn process_console_commands(auth_db: std::sync::Arc<AuthDatabase>) -> 
 async fn handle_command(cmd: WrathConsoleCommand, auth_db: std::sync::Arc<AuthDatabase>) -> Result<()> {
     match cmd {
         WrathConsoleCommand::CreateAccount(username, password) => handle_create_account(&username, &password, &auth_db).await?,
+        WrathConsoleCommand::Ban(username) => handle_ban(&username, &auth_db).await?,
+        WrathConsoleCommand::Unban(username) => handle_unban(&username, &auth_db).await?,
     }
     Ok(())
 }
@@ -47,5 +51,17 @@ async fn handle_create_account(username: &str, password: &str, auth_db: &std::sy
         .await?;
 
     info!("Account {} created", username);
+    Ok(())
+}
+
+async fn handle_ban(username: &str, auth_db: &std::sync::Arc<AuthDatabase>) -> Result<()> {
+    auth_db.set_account_ban_status(username, true).await?;
+    info!("Account {} banned", username);
+    Ok(())
+}
+
+async fn handle_unban(username: &str, auth_db: &std::sync::Arc<AuthDatabase>) -> Result<()> {
+    auth_db.set_account_ban_status(username, false).await?;
+    info!("Account {} unbanned", username);
     Ok(())
 }

--- a/databases/wrath-auth-db/migrations/20200830073445_setup.sql
+++ b/databases/wrath-auth-db/migrations/20200830073445_setup.sql
@@ -5,15 +5,14 @@ CREATE TABLE `accounts`
   `sessionkey` varchar(80) NOT NULL DEFAULT '',
   `v` varchar(64) NOT NULL DEFAULT '',
   `s` varchar(64) NOT NULL DEFAULT '',
-  `token_key` varchar(100) NOT NULL DEFAULT '',
   `banned` tinyint(1) unsigned zerofill NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   CONSTRAINT `username_unique` UNIQUE (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 INSERT INTO accounts VALUES
-(NULL, 'test', '', '313f948708ea1a2e3ad354b888d56329725c445411086a36133c033bbea6823f', 'de30ae3c971092b5bf5ad33cf9dbfa4b35f7a72e812ef6c8f3596ea272ac5467', '', 0),
-(NULL, 'banned', '', '320dee7fd506db6b4d3d559ca1d0c405e43224b1760afc26222afb59fbb7b872', '50f83a15afe7f792f29fd8c22d856739c590702c4692a6fc9c99c081fcf4700a', '', 1);
+(NULL, 'test', '', '313f948708ea1a2e3ad354b888d56329725c445411086a36133c033bbea6823f', 'de30ae3c971092b5bf5ad33cf9dbfa4b35f7a72e812ef6c8f3596ea272ac5467', 0),
+(NULL, 'banned', '', '320dee7fd506db6b4d3d559ca1d0c405e43224b1760afc26222afb59fbb7b872', '50f83a15afe7f792f29fd8c22d856739c590702c4692a6fc9c99c081fcf4700a', 1);
 
 CREATE TABLE `realms` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,

--- a/databases/wrath-auth-db/migrations/20200830073445_setup.sql
+++ b/databases/wrath-auth-db/migrations/20200830073445_setup.sql
@@ -7,7 +7,8 @@ CREATE TABLE `accounts`
   `s` varchar(64) NOT NULL DEFAULT '',
   `token_key` varchar(100) NOT NULL DEFAULT '',
   `banned` tinyint(1) unsigned zerofill NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  CONSTRAINT `username_unique` UNIQUE (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 INSERT INTO accounts VALUES

--- a/databases/wrath-auth-db/src/lib.rs
+++ b/databases/wrath-auth-db/src/lib.rs
@@ -71,6 +71,14 @@ impl AuthDatabase {
         Ok(())
     }
 
+    pub async fn set_account_ban_status(&self, username: &str, banned: bool) -> Result<()> {
+        let banned_int = banned as u8;
+        sqlx::query!("UPDATE `accounts` SET banned = ? WHERE username = ?;", banned_int, username)
+            .execute(&self.connection_pool)
+            .await?;
+        Ok(())
+    }
+
     pub async fn get_account_data(&self, account_id: u32) -> Result<Vec<DBAccountData>> {
         let acc_data = sqlx::query_as!(DBAccountData, "SELECT * FROM account_data WHERE account_id = ?", account_id)
             .fetch_all(&self.connection_pool)

--- a/databases/wrath-auth-db/src/structs.rs
+++ b/databases/wrath-auth-db/src/structs.rs
@@ -15,7 +15,6 @@ pub struct DBAccount {
     pub sessionkey: String,
     pub v: String,
     pub s: String,
-    pub token_key: String,
     pub banned: u8,
 }
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ cp .env.template .env
 cargo run
 ```
 Repeat these steps for the `world_server` folder to kick off a world server. You should now be able to log in with user `test` with password `test` using a 3.3.5(12340) game client and create your first character.
+
 ### After initial setup
 Some progress on the server code may change the database tables. In that case you will have to go into the database folders and run to bring your database up to the latest structure. This will wipe your database. This shouldn't be an issue since the server is nowhere near being able to host actual players anyway. 
 ```
@@ -37,3 +38,13 @@ cargo sqlx database create
 cargo sqlx migrate run
 ``` 
 
+Hint: Windows users can run `reset_db.bat` to quickly reset both the authentication and world databases. This requires `sqlx-cli` to be correctly installed.
+
+## Console Commands
+The authentication server accepts console commands to be typed while it's running. This is useful to control certain aspects of the authentication server and database, without having to resort to third-party database editing tools. Currently available console commands are:
+
+| Command                                | Description                                                                           |
+|----------------------------------------|---------------------------------------------------------------------------------------|
+| `create-account <username> <password>` | Inserts a fresh user into the database with the given username and password.          |
+| `ban <username>`                       | Bans a user in the database (does not currently disconnect them if they're connected) |
+| `unban <username>`                     | Unbans a user.                                                                        |

--- a/reset_db.bat
+++ b/reset_db.bat
@@ -1,0 +1,5 @@
+cd databases/wrath-auth-db/
+cargo sqlx database reset -y
+cd ../../databases/wrath-realm-db
+cargo sqlx database reset -y
+


### PR DESCRIPTION
Refactor the way we store account data. Since we are now correctly using @gtker's [wow_srp](https://github.com/gtker/wow_srp) package in the intended way, no longer store the hashed password, and store the verifier and salt upon account creation.

Account creation can now be done by inputting console commands into the auth server.

This brings changes that were already discussed in an older pull request from @WeaponMan [here](https://github.com/Victov/wrath-rs/pull/5#issuecomment-983436079). 