### PR TITLE
Add a basic docker-compose DB setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+
+services:
+  db:
+    image: mariadb:10.7
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: CHANGE_ME 
+    volumes:
+      - wrath-rs-database:/var/lib/mysql
+    ports:
+      - "3306:3306"
+      
+
+volumes:
+  wrath-rs-database:

--- a/docker/docker-setup.sh
+++ b/docker/docker-setup.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+export WRATH_RS_DIR="$PWD"
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+    echo 'ERROR: docker-compose is not installed.' >&2
+    exit 1
+fi
+
+if ! [ -d "$PWD/world_server" ] || ! [ -d "$PWD/auth_server" ]; then
+    echo "Please run docker/docker-setup.sh from the root wrath-rs directory."
+    exit 1
+fi
+
+# Check if SQLX CLI is installed.
+if ! cargo install --list | grep sqlx-cli > /dev/null 2>&1; then
+    echo "Installing sqlx-cli automatically..."
+    if ! cargo install sqlx-cli; then
+        echo "ERROR: automatic installation of sqlx-cli failed!"
+        echo "Please follow the instructions at https://github.com/launchbadge/sqlx/tree/master/sqlx-cli"
+        exit 1
+    fi
+    echo "Installation of sqlx-cli successful!"
+fi
+
+# Check if the user has already setup a docker container for wrath-rs, and forces the arg "--wipe" to be set before continuing.
+if docker volume ls | grep wrath-rs_wrath-rs-database > /dev/null 2>&1; then
+    if ! [ $# -gt 0 ] && ! [ "$1" = "--wipe" ]; then
+        echo "WARNING: There is already a pre-existing wrath-rs DB volume."
+        echo "Re-run docker-setup.sh with the '--wipe' arg if you wish to remove it and re-create the DB."
+        echo "THIS WILL DELETE ALL DATA FROM THE DB."
+        exit 1
+    fi
+fi
+
+# Prompt the user for a default ROOT password.
+echo "Please enter a ROOT password for your MariaDB container:"
+read root_password
+
+# Change the MariaDB root password in the docker-compose file.
+sed -i "s/MARIADB_ROOT_PASSWORD:.*/MARIADB_ROOT_PASSWORD: $root_password/g" docker-compose.yml
+
+# Setup .env files for the world/auth servers, pointing at the docker container.
+cp auth_server/.env.template auth_server/.env
+sed -E -i "s/AUTH_DATABASE_URL=.+/AUTH_DATABASE_URL=\"mysql:\/\/root:$root_password@localhost\/wrath_auth\"/g" auth_server/.env
+sed -E -i "s/DATABASE_URL=.+/DATABASE_URL=\"mysql:\/\/root:$root_password@localhost\/wrath_auth\"/g" databases/wrath-auth-db/.env
+
+cp world_server/.env.template world_server/.env
+sed -E -i "s/AUTH_DATABASE_URL=.+/AUTH_DATABASE_URL=\"mysql:\/\/root:$root_password@localhost\/wrath_auth\"/g" world_server/.env
+sed -E -i "s/REALM_DATABASE_URL=.+/REALM_DATABASE_URL=\"mysql:\/\/root:$root_password@localhost\/wrath_realm\"/g" world_server/.env
+sed -E -i "s/DATABASE_URL=.+/DATABASE_URL=\"mysql:\/\/root:$root_password@localhost\/wrath_realm\"/g" databases/wrath-realm-db/.env
+
+# Delete any pre-existing DB volumes.
+docker-compose down
+docker volume rm wrath-rs_wrath-rs-database
+
+# Bring up the DB.
+if ! docker-compose up -d db; then
+    echo "Failed to bring up the docker DB!"
+    exit 1
+fi
+
+# Run the migrations in each DB folder.
+cd "$WRATH_RS_DIR/databases/wrath-auth-db"
+cargo sqlx database drop
+cargo sqlx database create
+cargo sqlx migrate run
+
+cd "$WRATH_RS_DIR/databases/wrath-realm-db"
+cargo sqlx database drop
+cargo sqlx database create
+cargo sqlx migrate run

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,21 @@ cargo sqlx migrate run
 
 Hint: Windows users can run `reset_db.bat` to quickly reset both the authentication and world databases. This requires `sqlx-cli` to be correctly installed.
 
+## Dockerised Setup
+
+To bring up a MariaDB container for wrath-rs and point all .env files at the container, run the `docker/docker-setup.sh` file.
+
+**`docker` and `docker-compose` are required.**
+
+The setup script:
+    - Checks for all necessary pre-requisites (and attempts to automatically install sqlx-cli if needed).
+    - Sets a user-defined DB root password across all .env files, and in the MariaDB container.
+    - Deletes any pre-existing docker volumes (if run with `--wipe`).
+    - Runs the auth/world migrations against the new DB.
+
+Running the world/auth servers works exactly the same way as the normal installation process, using `cargo run` in the `auth_server` and `world_server` folders.
+Alternatively, if you just need to bring up a server quickly and don't need to input any commands or debug, you can use `launch.sh` in the root folder to run the auth and world servers in the same terminal.
+
 ## Console Commands
 Both the authentication server and the world server accept console commands to be typed while they're running. This is useful to control certain aspects of the servers and databases, without having to resort to third-party database editing tools. Currently available console commands are:
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if ! [ -d "$PWD/world_server" ] || ! [ -d "$PWD/auth_server" ]; then
+    echo "Please run start.sh from the root wrath-rs directory."
+    exit 1
+fi
+
+parallel -- "cd auth_server && cargo run" "cd world_server && cargo run"


### PR DESCRIPTION
Adds a very simple docker-compose setup, with an installation script that checks certain pre-requisites and configures all of the .env files to point at the docker container.