### PR TITLE
Fix formatting in README section about docker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,10 +54,10 @@ To bring up a MariaDB container for wrath-rs and point all .env files at the con
 **`docker` and `docker-compose` are required.**
 
 The setup script:
-    - Checks for all necessary pre-requisites (and attempts to automatically install sqlx-cli if needed).
-    - Sets a user-defined DB root password across all .env files, and in the MariaDB container.
-    - Deletes any pre-existing docker volumes (if run with `--wipe`).
-    - Runs the auth/world migrations against the new DB.
+- Checks for all necessary pre-requisites (and attempts to automatically install sqlx-cli if needed).
+- Sets a user-defined DB root password across all .env files, and in the MariaDB container.
+- Deletes any pre-existing docker volumes (if run with `--wipe`).
+- Runs the auth/world migrations against the new DB.
 
 Running the world/auth servers works exactly the same way as the normal installation process, using `cargo run` in the `auth_server` and `world_server` folders.
 Alternatively, if you just need to bring up a server quickly and don't need to input any commands or debug, you can use `launch.sh` in the root folder to run the auth and world servers in the same terminal.


### PR DESCRIPTION
Apparently lists don't render properly when they're tabbed in