### PR TITLE
Handle CMSG_WORLD_TELEPORT (worldport command)

### DIFF
--- a/world_server/Cargo.toml
+++ b/world_server/Cargo.toml
@@ -31,7 +31,7 @@ wow_srp = { version = "0.5" }
 #use specific git rev until release 0.1.1 arrivse on crates
 wow_dbc = { git = "https://github.com/gtker/wow_dbc.git", rev = "aac5da774d4861008120f18e0f5b74087f1bba45", features = ["wrath"] }
 
-wow_world_messages = { git="https://github.com/gtker/wow_messages.git", rev="ce06a26b4a1268a350de1e168eed2698cf69988e", features=["wrath", "async-std", "chrono"] }
+wow_world_messages = { git="https://github.com/gtker/wow_messages.git", rev="a9aead79aee73320e918d05b518f3093a9182529", features=["wrath", "async-std", "chrono"] }
 #For local testing purposes, one may want to switch to this local path version of wow_world_messages. Do not commit with this though
 #wow_world_messages = { path = "../../wow_messages/wow_world_messages", features=["wrath", "async-std", "chrono"] }
 

--- a/world_server/src/handlers/mod.rs
+++ b/world_server/src/handlers/mod.rs
@@ -62,6 +62,7 @@ pub use movement_handler::handle_cmsg_areatrigger;
 pub use movement_handler::handle_movement_generic;
 pub use movement_handler::handle_msg_move_teleport_ack;
 pub use movement_handler::handle_msg_move_worldport_ack;
+pub use movement_handler::handle_msg_world_teleport;
 pub use movement_handler::send_msg_move_teleport_ack;
 pub use movement_handler::send_smsg_force_move_root;
 pub use movement_handler::send_smsg_force_move_unroot;

--- a/world_server/src/packet_handler.rs
+++ b/world_server/src/packet_handler.rs
@@ -97,6 +97,7 @@ impl PacketHandler {
             ClientOpcodeMessage::MSG_MOVE_HEARTBEAT(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
             ClientOpcodeMessage::MSG_MOVE_TELEPORT_ACK(data) => handle_msg_move_teleport_ack(client_manager, packet.client_id, data).await,
             ClientOpcodeMessage::MSG_MOVE_WORLDPORT_ACK(data) => handle_msg_move_worldport_ack(client_manager, packet.client_id, world, data).await,
+            ClientOpcodeMessage::CMSG_WORLD_TELEPORT(data) => handle_msg_world_teleport(client_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_LOGOUT_REQUEST(data) => handle_cmsg_logout_request(client_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_LOGOUT_CANCEL(data) => handle_cmsg_logout_cancel(client_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_PLAYED_TIME(data) => handle_cmsg_played_time(client_manager, packet.client_id, data).await,


### PR DESCRIPTION
Adds support for the `worldport` command. E.G. `worldport orgrimmar` or `/console worldport orgrimmar`.

Merge after https://github.com/gtker/wow_messages/pull/48