### PR TITLE
Simplify github build workflow by removing database setup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,16 +11,6 @@ env:
 
 jobs:
   build:
-    services:
-      mysql:
-        image: mariadb:10.6
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: false
-          MYSQL_ROOT_PASSWORD: wrath
-          MYSQL_DATABASE: wrath
-        ports:
-          - 3306/tcp
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     runs-on: ubuntu-latest
     name: Wrath-rs on stable rust
     steps:
@@ -31,12 +21,5 @@ jobs:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
-      - name: Run migrations
-        run: |
-          mysql -h 127.0.0.1 -P ${{ job.services.mysql.ports['3306'] }} -u root -p'wrath' wrath < databases/wrath-auth-db/migrations/20200830073445_setup.sql
-          mysql -h 127.0.0.1 -P ${{ job.services.mysql.ports['3306'] }} -u root -p'wrath' wrath < databases/wrath-realm-db/migrations/20200919183322_setup.sql
       - name: Build
         run: cargo build
-        env:
-          DATABASE_URL: "mysql://root:wrath@localhost:${{ job.services.mysql.ports['3306'] }}/wrath"
-


### PR DESCRIPTION
Remove live database requirements from the github action now that offline compilation is supported.