### PR TITLE
Fix action bar handler

### DIFF
--- a/world_server/src/character/mod.rs
+++ b/world_server/src/character/mod.rs
@@ -200,7 +200,7 @@ impl Character {
         let (a, b, _, d) = self.gameplay_data.player_FIELD_BYTES().unwrap_or_default();
         //action_bars is a flags, no extra actionbars = 0, all bars (2 above default bar, 2 side
         //bars) is 15 when they are set visible in the Interface settings menu
-        self.gameplay_data.set_player_FIELD_BYTES(a, b, action_bars, d);
+        self.gameplay_data.set_player_FEATURES(a, b, action_bars, d);
     }
 
     fn set_rested_bytes(&mut self, rested: bool) -> Result<()> {

--- a/world_server/src/character/mod.rs
+++ b/world_server/src/character/mod.rs
@@ -197,7 +197,7 @@ impl Character {
     }
 
     pub fn set_visible_actionbar_mask(&mut self, action_bars: u8) {
-        let (a, b, _, d) = self.gameplay_data.player_FIELD_BYTES().unwrap_or_default();
+        let (a, b, _, d) = self.gameplay_data.player_FEATURES().unwrap_or_default();
         //action_bars is a flags, no extra actionbars = 0, all bars (2 above default bar, 2 side
         //bars) is 15 when they are set visible in the Interface settings menu
         self.gameplay_data.set_player_FEATURES(a, b, action_bars, d);


### PR DESCRIPTION
Seems player_FIELD_BYTES refers to index 153 which is the character style data(facial hair, hair and such) so toggling actionbars modifies that.
set_player_FEATURES is the correct index for this kind of info.