### PR TITLE
chore: updates wow_login_messages to 0.3 and wow_srp to 0.6

### DIFF
--- a/auth_server/Cargo.toml
+++ b/auth_server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wow_srp = '0.5.0'
+wow_srp = '0.6.0'
 byteorder = { version = '1' }
 async-std = { version = "1.12", features = ["unstable", "attributes"] }
 anyhow = { version = "*" }
@@ -20,4 +20,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 async-trait = "0.1"
 byte = "0.2"
 cmdparse = { version = "0.1" }
-wow_login_messages = { version="0.2", features=["async-std"] }
+wow_login_messages = { version="0.3", features=["async-std"] }

--- a/auth_server/src/auth.rs
+++ b/auth_server/src/auth.rs
@@ -22,7 +22,7 @@ pub async fn handle_logon_proof_srp(
     clients: ActiveClients,
     auth_database: std::sync::Arc<AuthDatabase>,
 ) -> Result<ClientState> {
-    let client_public_key = match PublicKey::from_le_bytes(&logon_proof.client_public_key) {
+    let client_public_key = match PublicKey::from_le_bytes(logon_proof.client_public_key) {
         Ok(key) => key,
         Err(_) => {
             reject_logon_proof(stream, CMD_AUTH_LOGON_PROOF_Server_LoginResult::FailIncorrectPassword).await?;

--- a/auth_server/src/realms.rs
+++ b/auth_server/src/realms.rs
@@ -74,14 +74,14 @@ async fn get_realm_list(auth_database: std::sync::Arc<AuthDatabase>, account_id:
         let mut flag = Realm_RealmFlag::new(realm.flags, None);
 
         if realm.online == 0 {
-            flag = flag.set_OFFLINE();
+            flag = flag.set_offline();
         }
 
         let realm_type: RealmType = RealmType::try_from(realm.realm_type).unwrap_or_default();
 
         realms.push(Realm {
             realm_type,
-            locked: 0,
+            locked: false,
             flag,
             name: realm.name,
             address: realm.ip,


### PR DESCRIPTION
A simple update on dependencies and fixed the `cargo build`. Tested spinning up both `auth` and `world` server.