### PR TITLE
world: Event‑driven connection & client managers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,9 @@
                     "kind": "bin"
                 }
             },
+            "env": {
+                "SMOL_THREADS": "4"
+            },
             "args": [],
             "cwd": "${workspaceFolder}/auth_server"
         },
@@ -37,6 +40,9 @@
                     "kind": "bin"
                 }
             },
+            "env": {
+                "SMOL_THREADS": "8"
+            },
             "args": [],
             "cwd": "${workspaceFolder}/world_server"
         },
@@ -46,7 +52,8 @@
             "name": "Debug 'wrath-authserver' and 'wrath-worldserver'",
             "configurations": [
                 "Debug executable 'wrath-authserver'",
-                "Debug executable 'wrath-worldserver'"]
+                "Debug executable 'wrath-worldserver'"
+            ]
         }
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,16 @@ members = [
     "tools/dbc-extractor",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+anyhow = { version = "*" }
+sqlx = { version = "0.7", features=["mysql", "runtime-async-std", "tls-rustls"] }
+flume = "0.11.1"
+smol = "2.0.2"
+tracing = { version = "0.1" }
+wow_login_messages = { version = "0.3", features = [ "async-std" ] }
+
+[workspace.dependencies.wow_world_messages]
+git = "https://github.com/gtker/wow_messages.git"
+rev = "55c2b641b7dbd09ca1de882f5fce814e4a91c068"
+features = [ "wrath", "async-std", "chrono" ]

--- a/auth_server/Cargo.toml
+++ b/auth_server/Cargo.toml
@@ -9,19 +9,19 @@ edition = "2021"
 [dependencies]
 wow_srp = '0.6.0'
 byteorder = { version = '1' }
-anyhow = { version = "*" }
+anyhow = { workspace = true }
 dotenvy = { version = "*" }
 hex = { version = "0.4" }
 wrath-auth-db = { path = "../databases/wrath-auth-db" }
 time = { version = "0.3", features = ["macros"] }
-tracing = { version = "0.1" }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 async-trait = "0.1"
 byte = "0.2"
 cmdparse = { version = "0.1" }
-wow_login_messages = { version="0.3", features=["async-std"] }
-smol = "2.0.2"
+wow_login_messages = { workspace = true }
+smol = { workspace = true}
 smol-macros = "0.1.0"
 macro_rules_attribute = "0.2.2"
 async-io = "2.5.0"
-flume = "0.11.1"
+flume = { workspace = true }

--- a/databases/wrath-auth-db/Cargo.toml
+++ b/databases/wrath-auth-db/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.32" }
-sqlx = { version = "0.7", features=["mysql", "runtime-async-std", "tls-rustls"] }
+anyhow = { workspace = true }
+sqlx = { workspace = true }

--- a/databases/wrath-realm-db/Cargo.toml
+++ b/databases/wrath-realm-db/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.32" }
-sqlx = { version = "0.7", features=["mysql", "runtime-async-std", "tls-rustls"] }
+anyhow = { workspace = true }
+sqlx = { workspace = true }

--- a/world_server/Cargo.toml
+++ b/world_server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = {version="0.1"}
-anyhow = { version = "1.0" }
+anyhow = { workspace = true }
 podio = { version = "0.2" } 
 dotenvy = { version="*" }
 rand = { version = "0.8" } 
@@ -20,7 +20,7 @@ chrono = { version = "0.4" }
 bit_field = { version = "0.10" }
 async-ctrlc = {version="1.2", features=["termination"] }
 time = { version = "0.3", features = ["macros"] }
-tracing = {version="0.1"}
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 rstar = { version = "0.9" }
 hex = { version = "0.4" }
@@ -33,10 +33,11 @@ wow_world_messages = { git="https://github.com/gtker/wow_messages.git", rev="55c
 wow_items = { git="https://github.com/gtker/wow_messages.git", rev="55c2b641b7dbd09ca1de882f5fce814e4a91c068", features = ["wrath"] }
 smol-macros = "0.1.1"
 macro_rules_attribute = "0.2.2"
-smol = "2.0.2"
+smol = { workspace = true }
 async-io = "2.5.0"
 futures-timer = "3.0.3"
 futures = "0.3.31"
+flume = { workspace = true }
 
 #For local testing purposes, one may want to switch to this local path version of wow_world_messages. Do not commit with this though
 #wow_world_messages = { path = "../../wow_messages/wow_world_messages", features=["wrath", "async-std", "chrono"] }

--- a/world_server/src/character/character_manager.rs
+++ b/world_server/src/character/character_manager.rs
@@ -1,0 +1,48 @@
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use tracing::info;
+use wow_world_messages::Guid;
+
+use crate::{character::Character, world::prelude::GameObject};
+
+#[derive(Default)]
+pub struct CharacterManager {
+    characters: HashMap<Guid, Character>,
+}
+
+impl CharacterManager {
+    pub fn new() -> Self {
+        Self { characters: HashMap::new() }
+    }
+
+    pub fn add_character(&mut self, character: Character) {
+        let guid = character.get_guid();
+        self.characters.insert(guid, character);
+    }
+
+    pub fn find_character(&self, guid: Guid) -> Option<&Character> {
+        self.characters.get(&guid)
+    }
+
+    pub fn find_character_mut(&mut self, guid: Guid) -> Option<&mut Character> {
+        self.characters.get_mut(&guid)
+    }
+
+    pub fn get_character(&self, guid: Guid) -> Result<&Character> {
+        self.characters
+            .get(&guid)
+            .ok_or(anyhow!("Character with guid {} not found in character manager", guid))
+    }
+
+    pub fn get_character_mut(&mut self, guid: Guid) -> Result<&mut Character> {
+        self.characters
+            .get_mut(&guid)
+            .ok_or(anyhow!("Character with guid {} not found in character manager", guid))
+    }
+
+    pub fn remove_character(&mut self, guid: Guid) {
+        info!("Character with guid {} removed from character manager", guid);
+        self.characters.remove(&guid);
+    }
+}

--- a/world_server/src/client.rs
+++ b/world_server/src/client.rs
@@ -1,25 +1,13 @@
 use super::character::*;
-use super::client_manager::ClientManager;
-use crate::handlers::handle_cmsg_auth_session;
+use crate::character::character_manager::CharacterManager;
+use crate::connection::events::ServerEvent;
+use crate::data::DataStorage;
 use crate::handlers::login_handler::LogoutState;
-use crate::packet_handler::PacketToHandle;
 use crate::prelude::*;
 use crate::world::World;
-use smol::lock::{Mutex, RwLock};
-use smol::net::TcpStream;
-use std::sync::mpsc::Sender;
+use std::net::SocketAddr;
 use std::sync::Arc;
-use wow_srp::wrath_header::ProofSeed;
-use wow_srp::wrath_header::ServerDecrypterHalf;
-use wow_srp::wrath_header::ServerEncrypterHalf;
-use wow_world_messages::errors::ExpectedOpcodeError;
-use wow_world_messages::wrath::astd_expect_client_message;
-use wow_world_messages::wrath::opcodes::ClientOpcodeMessage;
-use wow_world_messages::wrath::ServerMessage;
-use wow_world_messages::wrath::CMSG_AUTH_SESSION;
-use wow_world_messages::wrath::SMSG_AUTH_CHALLENGE;
 use wow_world_messages::Guid;
-use wrath_auth_db::AuthDatabase;
 
 #[derive(Clone, PartialEq, Eq)]
 pub enum ClientState {
@@ -31,185 +19,94 @@ pub enum ClientState {
 
 pub struct ClientData {
     pub client_state: ClientState,
-    pub account_id: Option<u32>,
-    pub active_character: Option<Arc<RwLock<Character>>>,
+    pub account_id: u32,
+    pub active_character: Option<Guid>,
 }
 
 pub struct Client {
-    pub id: u64,
-    pub read_socket: Arc<RwLock<TcpStream>>,
-    pub write_socket: Arc<Mutex<TcpStream>>,
-    pub encryption: Mutex<Option<ServerEncrypterHalf>>,
-    pub decryption: Mutex<Option<ServerDecrypterHalf>>,
-    pub data: RwLock<ClientData>,
+    pub id: SocketAddr,
+
+    pub connection_sender: flume::Sender<ServerEvent>,
+
+    pub data: ClientData,
 }
 
 impl Client {
-    pub fn new(id: u64, read_socket: Arc<RwLock<TcpStream>>, write_socket: Arc<Mutex<TcpStream>>) -> Self {
+    pub fn new(id: SocketAddr, account_id: u32, connection_sender: flume::Sender<ServerEvent>) -> Self {
         Self {
             id,
-            read_socket,
-            write_socket,
-            encryption: Mutex::new(None),
-            decryption: Mutex::new(None),
-            data: RwLock::new(ClientData {
-                client_state: ClientState::PreLogin,
-                account_id: None,
+            connection_sender,
+
+            data: ClientData {
+                client_state: ClientState::CharacterSelection,
+                account_id,
                 active_character: None,
-            }),
+            },
         }
     }
 
-    pub async fn tick(&self, delta_time: f32, world: Arc<World>) -> Result<()> {
+    pub async fn tick(&mut self, delta_time: f32, character_manager: &mut CharacterManager, world: &mut World) -> Result<()> {
         let mut should_return_to_character_select: bool = false;
-        if let Some(character_lock) = &self.data.read().await.active_character {
-            let mut character = character_lock.write().await;
+        if let Some(guid) = self.data.active_character {
+            let character = character_manager.get_character_mut(guid)?;
             character.tick(delta_time, world).await?;
 
             should_return_to_character_select = character.logout_state == LogoutState::ReturnToCharSelect;
         }
 
         if should_return_to_character_select {
-            let data = &mut self.data.write().await;
+            let data = &mut self.data;
             data.active_character = None;
             data.client_state = ClientState::CharacterSelection;
         }
         Ok(())
     }
 
-    pub async fn authenticate_and_start_receiving_data(&self, packet_handle_sender: Sender<PacketToHandle>, auth_db: Arc<AuthDatabase>) {
-        let proof_seed = ProofSeed::new();
-        self.send_auth_challenge(&proof_seed).await.unwrap_or_else(|e| {
-            error!("Error while sending auth challenge: {:?}", e);
-        });
-
-        let auth_session_packet = {
-            let mut read_socket = self.read_socket.write().await;
-            astd_expect_client_message::<CMSG_AUTH_SESSION, _>(&mut *read_socket).await
-        };
-
-        if let Ok(auth_session_packet) = auth_session_packet {
-            handle_cmsg_auth_session(self, proof_seed, &auth_session_packet, auth_db)
-                .await
-                .unwrap_or_else(|e| {
-                    warn!("Error while authenticating {:?}", e);
-                });
-
-            self.handle_incoming_packets(packet_handle_sender).await.unwrap_or_else(|e| {
-                warn!("Error while handling packet {:?}", e);
-            });
-        }
-
-        //Client stopped handling packets. Probably disconnected. Remove from client list?
-        self.disconnect()
-            .await
-            .unwrap_or_else(|e| warn!("Something went wrong while disconnecting client: {:?}", e));
+    pub fn get_active_character(&self) -> Guid {
+        self.data.active_character.unwrap()
     }
 
-    async fn handle_incoming_packets(&self, packet_channel: Sender<PacketToHandle>) -> Result<()> {
-        loop {
-            if !self.is_authenticated().await {
-                break;
-            }
-            let opcode = {
-                let decryptor_opt: &mut Option<ServerDecrypterHalf> = &mut *self.decryption.lock().await;
-                if let Some(decryption) = decryptor_opt.as_mut() {
-                    let mut read_socket = self.read_socket.write().await;
-                    ClientOpcodeMessage::astd_read_encrypted(&mut *read_socket, decryption).await
-                } else {
-                    bail!("Encryption didn't exist");
-                }
-            };
-            if let Ok(op) = opcode {
-                packet_channel.send(PacketToHandle {
-                    client_id: self.id,
-                    payload: Box::new(op),
-                })?;
-            } else if let Err(e) = opcode {
-                if let ExpectedOpcodeError::Io(_) = e {
-                    error!("IO error during parsing, there is no recovery from this, disconnect client");
-                    break;
-                }
-                warn!("Error in opcode: {}.", e);
-            }
-        }
-        Ok(())
-    }
-
-    pub async fn get_active_character(&self) -> Result<Arc<RwLock<Character>>> {
-        let data = self.data.read().await;
-        let arc = data.active_character.as_ref().ok_or_else(|| anyhow!("No active character"))?;
-        Ok(arc.clone())
-    }
-
-    pub async fn disconnect(&self) -> Result<()> {
-        //Kill all networking, but allow the world one frame to do cleanup
-        //For example, keep around the active character, so that the instance manager can see that
-        //we're disconnected, but still access the character to do world cleanup
-        info!("A client disconnected");
-
-        {
-            let data = &mut self.data.write().await;
-            data.client_state = ClientState::DisconnectPendingCleanup;
-        }
-        self.read_socket.write().await.shutdown(smol::net::Shutdown::Both)?;
-        self.write_socket.lock().await.shutdown(std::net::Shutdown::Both)?;
-        //Save character to db?
-        Ok(())
-    }
-
-    pub async fn disconnected_post_cleanup(&self) -> Result<()> {
+    pub fn disconnected_post_cleanup(&mut self) -> Result<()> {
         //Cleanup time has passed. Now this client is really really disconnected and
         //will be fully removed from memory
-        let data = &mut self.data.write().await;
+        let data = &mut self.data;
         data.client_state = ClientState::Disconnected;
-        data.account_id = None;
         data.active_character = None;
         Ok(())
     }
 
-    pub async fn send_auth_challenge(&self, proof_seed: &ProofSeed) -> Result<()> {
-        let mut stream = self.write_socket.lock().await;
-        SMSG_AUTH_CHALLENGE {
-            unknown1: 1,
-            server_seed: proof_seed.seed(),
-            seed: [0_u8; 32],
-        }
-        .astd_write_unencrypted_server(&mut *stream)
-        .await
-        .unwrap();
+    pub fn is_authenticated(&self) -> bool {
+        self.data.client_state != ClientState::PreLogin
+    }
 
+    pub async fn load_and_set_active_character(
+        &mut self,
+        character_manager: &mut CharacterManager,
+        data_storage: &Arc<DataStorage>,
+        world: &World,
+        character_guid: Guid,
+    ) -> Result<()> {
+        // TODO: send a message to the character manager?
+        let character = Character::load(self.connection_sender.clone(), character_guid, world, data_storage).await?;
+        character_manager.add_character(character);
+        self.data.active_character.replace(character_guid);
         Ok(())
     }
 
-    pub async fn is_authenticated(&self) -> bool {
-        let data = self.data.read().await;
-        data.account_id.is_some() && data.client_state != ClientState::PreLogin
+    pub fn set_active_character(&mut self, character_guid: Guid) {
+        self.data.active_character.replace(character_guid);
     }
 
-    pub async fn load_and_set_active_character(&self, client_manager: &ClientManager, world: &World, character_guid: Guid) -> Result<()> {
-        let weakself = Arc::downgrade(&client_manager.get_client(self.id).await?);
-        let character = Character::load(weakself, character_guid, world, &client_manager.data_storage).await?;
-        let character_arc = Arc::new(RwLock::new(character));
-
-        let mut data = self.data.write().await;
-        data.active_character = Some(character_arc.clone());
-
-        Ok(())
-    }
-
-    pub async fn login_active_character(&self, world: &World) -> Result<()> {
-        let data = self.data.read().await;
-        let character_lock = data.active_character.as_ref().unwrap();
-        let character = character_lock.read().await;
+    pub async fn login_active_character(&self, world: &mut World, character_manager: &mut CharacterManager) -> Result<()> {
+        let data = &self.data;
+        let character = character_manager.get_character_mut(data.active_character.unwrap())?;
         character.send_packets_before_add_to_map().await?;
 
         world
-            .get_instance_manager()
-            .get_or_create_map(&(*character), character.map)
+            .get_instance_manager_mut()
+            .get_or_create_map(character, character.map)
             .await?
-            .push_object(Arc::downgrade(character_lock))
-            .await;
+            .push_character(character);
 
         character.send_packets_after_add_to_map(world.get_realm_database()).await?;
 

--- a/world_server/src/client_manager.rs
+++ b/world_server/src/client_manager.rs
@@ -1,58 +1,106 @@
 use super::client::*;
-use super::packet_handler::PacketToHandle;
+use crate::character::character_manager::CharacterManager;
+use crate::character::Character;
+use crate::connection::events::ClientEvent;
 use crate::data::DataStorage;
+use crate::packet_handler::{PacketHandler, PacketToHandle};
 use crate::prelude::*;
 use crate::world::prelude::GameObject;
 use crate::world::World;
-use rand::{thread_rng, RngCore};
-use smol::lock::{Mutex, RwLock};
-use smol::net::TcpListener;
-use smol::stream::StreamExt;
 use std::collections::HashMap;
-use std::sync::mpsc::Sender;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use wrath_auth_db::AuthDatabase;
 
 pub struct ClientManager {
     pub auth_db: Arc<AuthDatabase>,
     pub data_storage: Arc<DataStorage>,
-    clients: RwLock<HashMap<u64, Arc<Client>>>,
+    clients: HashMap<SocketAddr, Client>,
+
+    sender: flume::Sender<ClientEvent>,
+    pub receiver: flume::Receiver<ClientEvent>,
 }
 
 impl ClientManager {
     pub fn new(auth_db: Arc<AuthDatabase>, data_storage: Arc<DataStorage>) -> Self {
+        let (sender, receiver) = flume::unbounded();
         Self {
             auth_db,
             data_storage,
-            clients: RwLock::new(HashMap::new()),
+            clients: HashMap::new(),
+            sender,
+            receiver,
         }
     }
 
-    pub async fn tick(&self, delta_time: f32, world: Arc<World>) -> Result<()> {
-        self.cleanup_disconnected_clients(world.clone()).await?;
-        let clients = self.clients.read().await;
-        for (_, client) in clients.iter() {
-            client.tick(delta_time, world.clone()).await?;
+    pub fn get_sender(&self) -> flume::Sender<ClientEvent> {
+        self.sender.clone()
+    }
+
+    pub async fn tick(&mut self, delta_time: f32, character_manager: &mut CharacterManager, world: &mut World) -> Result<()> {
+        self.cleanup_disconnected_clients(character_manager, world).await?;
+        self.handle_connection_events(character_manager, world).await?;
+        let clients = &mut self.clients;
+        for (_, client) in clients.iter_mut() {
+            client.tick(delta_time, character_manager, world).await?;
         }
 
         Ok(())
     }
 
-    async fn cleanup_disconnected_clients(&self, world: Arc<World>) -> Result<()> {
+    async fn handle_connection_events(&mut self, character_manager: &mut CharacterManager, world: &mut World) -> Result<()> {
+        while let Ok(event) = self.receiver.try_recv() {
+            match event {
+                ClientEvent::Connected {
+                    addr,
+                    account_id,
+                    connection_sender,
+                } => {
+                    let client = Client::new(addr, account_id, connection_sender);
+                    self.clients.insert(addr, client);
+                }
+                ClientEvent::Disconnected { addr } => {
+                    if let Some(client) = self.clients.get_mut(&addr) {
+                        client.data.client_state = ClientState::DisconnectPendingCleanup;
+                    } else {
+                        error!("Received disconnect event for unknown client: {}", addr);
+                    }
+                }
+                ClientEvent::Message { addr, packet } => {
+                    let packet_to_handle = PacketToHandle {
+                        client_id: addr,
+                        payload: Box::new(packet),
+                    };
+                    PacketHandler::handle_packet(self, character_manager, world, packet_to_handle).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn remove_client(&mut self, client_id: SocketAddr) -> Option<Client> {
+        self.clients.remove(&client_id)
+    }
+
+    async fn cleanup_disconnected_clients(&mut self, character_manager: &CharacterManager, world: &mut World) -> Result<()> {
         let to_remove = {
             let mut result = vec![];
-            let clients = self.clients.read().await;
-            for (id, client) in clients.iter() {
+            let clients = &mut self.clients;
+            for (id, client) in clients.iter_mut() {
                 //Cleanup is two-staged. Sockets are already closed here, but we take this frame to
                 //be able to remove them from the world and all that cleanup
                 let client_state = {
-                    let data = client.data.read().await;
+                    let data = &client.data;
                     data.client_state.clone()
                 };
                 if client_state == ClientState::DisconnectPendingCleanup {
-                    world.get_instance_manager().handle_client_disconnected(client).await?;
+                    world
+                        .get_instance_manager_mut()
+                        .handle_client_disconnected(client, character_manager)
+                        .await?;
                     //insert more cleanup actions here
-                    client.disconnected_post_cleanup().await?;
+                    client.disconnected_post_cleanup()?;
                 } else if client_state == ClientState::Disconnected {
                     //Here the client is disconnected and cleanup is done.
                     //insert id so we can clean that hashmap later
@@ -65,92 +113,74 @@ impl ClientManager {
             return Ok(());
         }
 
-        let mut write_clients = self.clients.write().await;
+        let write_clients = &mut self.clients;
         write_clients.retain(|id, _| !to_remove.contains(id));
         info!("Cleaned up {} clients, {} clients left online", to_remove.len(), write_clients.len());
 
         Ok(())
     }
 
-    pub async fn accept_realm_connections(&self, packet_handle_sender: Sender<PacketToHandle>) -> Result<()> {
-        let realm_id: i32 = std::env::var("REALM_ID")?.parse()?;
-        let bind_ip = self.auth_db.get_realm_bind_ip(realm_id).await?;
-        let tcp_listener = TcpListener::bind(bind_ip).await?;
-        let mut incoming_connections = tcp_listener.incoming();
-
-        while let Some(tcp_stream) = incoming_connections.next().await {
-            let read_stream = tcp_stream?;
-            let write_stream = read_stream.clone();
-            let read_socket_wrapped = Arc::new(RwLock::new(read_stream));
-            let write_socket_wrapped = Arc::new(Mutex::new(write_stream));
-            let client_id = thread_rng().next_u64();
-            let client = Arc::new(Client::new(client_id, read_socket_wrapped.clone(), write_socket_wrapped));
-
-            {
-                let mut hashmap = self.clients.write().await;
-                hashmap.insert(client_id, client.clone());
-            }
-            {
-                //Have to make local copies of all these things to avoid `self` references in the
-                //asyncmove block.
-                let client = client.clone();
-                let packet_handle_sender = packet_handle_sender.clone();
-                let auth_db = self.auth_db.clone();
-                smol::spawn(async move {
-                    let p = packet_handle_sender.clone();
-                    let a_db = auth_db.clone();
-                    client.authenticate_and_start_receiving_data(p, a_db).await;
-                })
-                .detach();
-            }
-        }
-
-        Ok(())
-    }
-
-    pub async fn get_authenticated_client(&self, id: u64) -> Result<Arc<Client>> {
-        let client = self.get_client(id).await?;
-        if !client.is_authenticated().await {
+    pub fn get_authenticated_client(&self, id: SocketAddr) -> Result<&Client> {
+        let client = self.get_client(id)?;
+        if !client.is_authenticated() {
             bail!("Character isn't authenticated");
         }
         Ok(client)
     }
 
-    pub async fn get_client(&self, id: u64) -> Result<Arc<Client>> {
-        let hashmap = self.clients.read().await;
-        let clientlock = hashmap.get(&id).ok_or_else(|| anyhow!("Failed to get client for client id: {}", id))?;
-        Ok(clientlock.clone())
+    pub async fn get_authenticated_client_mut(&mut self, id: SocketAddr) -> Result<&mut Client> {
+        let client = self.get_client_mut(id).await?;
+        if !client.is_authenticated() {
+            bail!("Character isn't authenticated");
+        }
+        Ok(client)
+    }
+
+    pub async fn get_character_from_client(&self, id: SocketAddr) -> Result<Guid> {
+        let client = self.get_authenticated_client(id)?;
+        Ok(client.get_active_character())
+    }
+
+    pub fn get_client(&self, id: SocketAddr) -> Result<&Client> {
+        let hashmap = &self.clients;
+        hashmap.get(&id).ok_or_else(|| anyhow!("Failed to get client for client id: {}", id))
+    }
+
+    pub async fn get_client_mut(&mut self, id: SocketAddr) -> Result<&mut Client> {
+        let hashmap = &mut self.clients;
+        hashmap.get_mut(&id).ok_or_else(|| anyhow!("Failed to get client for client id: {}", id))
     }
 
     //Attempts to find a client based on the character's name that they are currently playing.
-    pub async fn find_client_from_active_character_name(&self, character_name: &str) -> Result<Option<Arc<Client>>> {
-        let clients = self.clients.read().await;
+    pub fn find_client_from_active_character_name(&self, character_name: &str, character_manager: &CharacterManager) -> Result<&Client> {
+        let clients = &self.clients;
         for (_, client) in clients.iter() {
-            let client_data = client.data.read().await;
-            if let Some(active_character_lock) = &client_data.active_character {
-                let active_character = active_character_lock.read().await;
-                if active_character.name.to_uppercase().trim() == character_name.to_uppercase().trim() {
-                    return Ok(Some(client.clone()));
+            if let Some(active_character) = client.data.active_character {
+                let character = character_manager.get_character(active_character)?;
+                if character.name.to_uppercase().trim() == character_name.to_uppercase().trim() {
+                    return Ok(client);
                 }
             }
         }
 
-        Ok(None)
+        Err(anyhow!("Failed to find client for character {}", character_name))
     }
 
     //Attempts to find a client based on the character's guid that they are currently playing.
-    pub async fn find_client_from_active_character_guid(&self, character_guid: &Guid) -> Result<Option<Arc<Client>>> {
-        let clients = self.clients.read().await;
+    pub fn find_client_from_active_character_guid(&self, character_guid: Guid) -> Result<&Client> {
+        let clients = &self.clients;
         for (_, client) in clients.iter() {
-            let client_data = client.data.read().await;
-            if let Some(active_character_lock) = &client_data.active_character {
-                let active_character = active_character_lock.read().await;
-                if active_character.get_guid() == *character_guid {
-                    return Ok(Some(client.clone()));
+            if let Some(guid) = client.data.active_character {
+                if guid == character_guid {
+                    return Ok(client);
                 }
             }
         }
 
-        Ok(None)
+        Err(anyhow!("Failed to find client for character {}", character_guid))
+    }
+
+    pub fn get_client_from_character(&self, character: &Character) -> Result<&Client> {
+        self.find_client_from_active_character_guid(character.get_guid())
     }
 }

--- a/world_server/src/connection/events.rs
+++ b/world_server/src/connection/events.rs
@@ -1,0 +1,297 @@
+use std::{fmt, net::SocketAddr};
+
+use wow_world_messages::wrath::{opcodes::ClientOpcodeMessage, *};
+
+/// Events produced by the network/IO layer and consumed by the client manager.
+#[allow(clippy::large_enum_variant)]
+pub enum ClientEvent {
+    Connected {
+        addr: SocketAddr,
+        account_id: u32,
+        // This sender is used to send messages back to the client from the manager
+        connection_sender: flume::Sender<ServerEvent>,
+    },
+    Disconnected {
+        addr: SocketAddr,
+    },
+    Message {
+        addr: SocketAddr,
+        packet: ClientOpcodeMessage,
+    },
+}
+
+/// Events sent by the client manager back to the connection writer for delivery to the client.
+#[derive(Clone)]
+pub enum ServerEvent {
+    AccountDataTimes(SMSG_ACCOUNT_DATA_TIMES),
+    ActionButtons(SMSG_ACTION_BUTTONS),
+    BindPointUpdate(SMSG_BINDPOINTUPDATE),
+    CalendarSendNumPending(SMSG_CALENDAR_SEND_NUM_PENDING),
+    CharCreate(SMSG_CHAR_CREATE),
+    CharDelete(SMSG_CHAR_DELETE),
+    CharEnum(SMSG_CHAR_ENUM),
+    ContactList(SMSG_CONTACT_LIST),
+    DestroyObject(SMSG_DESTROY_OBJECT),
+    Disconnect,
+    FeatureSystemStatus(SMSG_FEATURE_SYSTEM_STATUS),
+    ForceMoveRoot(SMSG_FORCE_MOVE_ROOT),
+    ForceMoveUnroot(SMSG_FORCE_MOVE_UNROOT),
+    GMTicketGetTicket(SMSG_GMTICKET_GETTICKET),
+    GMTicketSystemStatus(SMSG_GMTICKET_SYSTEMSTATUS),
+    InitializeFactions(SMSG_INITIALIZE_FACTIONS),
+    InitialSpells(SMSG_INITIAL_SPELLS),
+    InitWorldStates(SMSG_INIT_WORLD_STATES),
+    ItemNameQueryResponse(SMSG_ITEM_NAME_QUERY_RESPONSE),
+    ItemQuerySingleResponse(SMSG_ITEM_QUERY_SINGLE_RESPONSE),
+    LoginSetTimeSpeed(SMSG_LOGIN_SETTIMESPEED),
+    LoginVerifyWorld(SMSG_LOGIN_VERIFY_WORLD),
+    LogoutCancelAck(SMSG_LOGOUT_CANCEL_ACK),
+    LogoutComplete(SMSG_LOGOUT_COMPLETE),
+    LogoutResponse(SMSG_LOGOUT_RESPONSE),
+    MessageChat(SMSG_MESSAGECHAT),
+    MoveTeleportAck(MSG_MOVE_TELEPORT_ACK_Server),
+    MoveStartForward(MSG_MOVE_START_FORWARD),
+    MoveStartBackward(MSG_MOVE_START_BACKWARD),
+    MoveStop(MSG_MOVE_STOP),
+    MoveStopTurn(MSG_MOVE_STOP_TURN),
+    MoveStartStrafeLeft(MSG_MOVE_START_STRAFE_LEFT),
+    MoveStartStrafeRight(MSG_MOVE_START_STRAFE_RIGHT),
+    MoveStopStrafe(MSG_MOVE_STOP_STRAFE),
+    MoveJump(MSG_MOVE_JUMP),
+    MoveStartTurnLeft(MSG_MOVE_START_TURN_LEFT),
+    MoveStartTurnRight(MSG_MOVE_START_TURN_RIGHT),
+    MoveStartPitchUp(MSG_MOVE_START_PITCH_UP),
+    MoveStartPitchDown(MSG_MOVE_START_PITCH_DOWN),
+    MoveStopPitch(MSG_MOVE_STOP_PITCH),
+    MoveSetRunMode(MSG_MOVE_SET_RUN_MODE),
+    MoveSetWalkMode(MSG_MOVE_SET_WALK_MODE),
+    MoveFallLand(MSG_MOVE_FALL_LAND),
+    MoveStartSwim(MSG_MOVE_START_SWIM),
+    MoveStopSwim(MSG_MOVE_STOP_SWIM),
+    MoveSetFacing(MSG_MOVE_SET_FACING),
+    MoveHeartbeat(MSG_MOVE_HEARTBEAT),
+    NameQueryResponse(SMSG_NAME_QUERY_RESPONSE),
+    NewWorld(SMSG_NEW_WORLD),
+    PlayedTime(SMSG_PLAYED_TIME),
+    QueryTimeResponse(SMSG_QUERY_TIME_RESPONSE),
+    Pong(SMSG_PONG),
+    RaidInstanceInfo(SMSG_RAID_INSTANCE_INFO),
+    RealmSplit(SMSG_REALM_SPLIT),
+    SetDungeonDifficulty(MSG_SET_DUNGEON_DIFFICULTY_Server),
+    StandStateUpdate(SMSG_STANDSTATE_UPDATE),
+    TimeSyncReq(SMSG_TIME_SYNC_REQ),
+    TransferPending(SMSG_TRANSFER_PENDING),
+    TriggerCinematic(SMSG_TRIGGER_CINEMATIC),
+    TutorialFlags(SMSG_TUTORIAL_FLAGS),
+    UpdateAccountData(SMSG_UPDATE_ACCOUNT_DATA),
+    UpdateAccountDataComplete(SMSG_UPDATE_ACCOUNT_DATA_COMPLETE),
+    UpdateObject(SMSG_UPDATE_OBJECT),
+    UpdateWorldState(SMSG_UPDATE_WORLD_STATE),
+    WorldStateUiTimerUpdate(SMSG_WORLD_STATE_UI_TIMER_UPDATE),
+}
+
+impl fmt::Display for ServerEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServerEvent::AccountDataTimes(_) => write!(f, "SMSG_ACCOUNT_DATA_TIMES"),
+            ServerEvent::ActionButtons(_) => write!(f, "SMSG_ACTION_BUTTONS"),
+            ServerEvent::BindPointUpdate(_) => write!(f, "SMSG_BINDPOINTUPDATE"),
+            ServerEvent::CalendarSendNumPending(_) => write!(f, "SMSG_CALENDAR_SEND_NUM_PENDING"),
+            ServerEvent::CharCreate(_) => write!(f, "SMSG_CHAR_CREATE"),
+            ServerEvent::CharDelete(_) => write!(f, "SMSG_CHAR_DELETE"),
+            ServerEvent::CharEnum(_) => write!(f, "SMSG_CHAR_ENUM"),
+            ServerEvent::ContactList(_) => write!(f, "SMSG_CONTACT_LIST"),
+            ServerEvent::DestroyObject(_) => write!(f, "SMSG_DESTROY_OBJECT"),
+            ServerEvent::Disconnect => write!(f, "Disconnect"),
+            ServerEvent::FeatureSystemStatus(_) => write!(f, "SMSG_FEATURE_SYSTEM_STATUS"),
+            ServerEvent::ForceMoveRoot(_) => write!(f, "SMSG_FORCE_MOVE_ROOT"),
+            ServerEvent::ForceMoveUnroot(_) => write!(f, "SMSG_FORCE_MOVE_UNROOT"),
+            ServerEvent::GMTicketGetTicket(_) => write!(f, "SMSG_GMTICKET_GETTICKET"),
+            ServerEvent::GMTicketSystemStatus(_) => write!(f, "SMSG_GMTICKET_SYSTEMSTATUS"),
+            ServerEvent::InitializeFactions(_) => write!(f, "SMSG_INITIALIZE_FACTIONS"),
+            ServerEvent::InitialSpells(_) => write!(f, "SMSG_INITIAL_SPELLS"),
+            ServerEvent::InitWorldStates(_) => write!(f, "SMSG_INIT_WORLD_STATES"),
+            ServerEvent::ItemNameQueryResponse(_) => write!(f, "SMSG_ITEM_NAME_QUERY_RESPONSE"),
+            ServerEvent::ItemQuerySingleResponse(_) => write!(f, "SMSG_ITEM_QUERY_SINGLE_RESPONSE"),
+            ServerEvent::LoginSetTimeSpeed(_) => write!(f, "SMSG_LOGIN_SETTIMESPEED"),
+            ServerEvent::LoginVerifyWorld(_) => write!(f, "SMSG_LOGIN_VERIFY_WORLD"),
+            ServerEvent::LogoutCancelAck(_) => write!(f, "SMSG_LOGOUT_CANCEL_ACK"),
+            ServerEvent::LogoutComplete(_) => write!(f, "SMSG_LOGOUT_COMPLETE"),
+            ServerEvent::LogoutResponse(_) => write!(f, "SMSG_LOGOUT_RESPONSE"),
+            ServerEvent::MessageChat(_) => write!(f, "SMSG_MESSAGECHAT"),
+            ServerEvent::MoveTeleportAck(_) => write!(f, "MSG_MOVE_TELEPORT_ACK_Server"),
+            ServerEvent::MoveStartForward(_) => write!(f, "MSG_MOVE_START_FORWARD"),
+            ServerEvent::MoveStartBackward(_) => write!(f, "MSG_MOVE_START_BACKWARD"),
+            ServerEvent::MoveStop(_) => write!(f, "MSG_MOVE_STOP"),
+            ServerEvent::MoveStopTurn(_) => write!(f, "MSG_MOVE_STOP_TURN"),
+            ServerEvent::MoveStartStrafeLeft(_) => write!(f, "MSG_MOVE_START_STRAFE_LEFT"),
+            ServerEvent::MoveStartStrafeRight(_) => write!(f, "MSG_MOVE_START_STRAFE_RIGHT"),
+            ServerEvent::MoveStopStrafe(_) => write!(f, "MSG_MOVE_STOP_STRAFE"),
+            ServerEvent::MoveJump(_) => write!(f, "MSG_MOVE_JUMP"),
+            ServerEvent::MoveStartTurnLeft(_) => write!(f, "MSG_MOVE_START_TURN_LEFT"),
+            ServerEvent::MoveStartTurnRight(_) => write!(f, "MSG_MOVE_START_TURN_RIGHT"),
+            ServerEvent::MoveStartPitchUp(_) => write!(f, "MSG_MOVE_START_PITCH_UP"),
+            ServerEvent::MoveStartPitchDown(_) => write!(f, "MSG_MOVE_START_PITCH_DOWN"),
+            ServerEvent::MoveStopPitch(_) => write!(f, "MSG_MOVE_STOP_PITCH"),
+            ServerEvent::MoveSetRunMode(_) => write!(f, "MSG_MOVE_SET_RUN_MODE"),
+            ServerEvent::MoveSetWalkMode(_) => write!(f, "MSG_MOVE_SET_WALK_MODE"),
+            ServerEvent::MoveFallLand(_) => write!(f, "MSG_MOVE_FALL_LAND"),
+            ServerEvent::MoveStartSwim(_) => write!(f, "MSG_MOVE_START_SWIM"),
+            ServerEvent::MoveStopSwim(_) => write!(f, "MSG_MOVE_STOP_SWIM"),
+            ServerEvent::MoveSetFacing(_) => write!(f, "MSG_MOVE_SET_FACING"),
+            ServerEvent::MoveHeartbeat(_) => write!(f, "MSG_MOVE_HEARTBEAT"),
+            ServerEvent::NameQueryResponse(_) => write!(f, "SMSG_NAME_QUERY_RESPONSE"),
+            ServerEvent::NewWorld(_) => write!(f, "SMSG_NEW_WORLD"),
+            ServerEvent::PlayedTime(_) => write!(f, "SMSG_PLAYED_TIME"),
+            ServerEvent::QueryTimeResponse(_) => write!(f, "SMSG_QUERY_TIME_RESPONSE"),
+            ServerEvent::Pong(_) => write!(f, "SMSG_PONG"),
+            ServerEvent::RaidInstanceInfo(_) => write!(f, "SMSG_RAID_INSTANCE_INFO"),
+            ServerEvent::RealmSplit(_) => write!(f, "SMSG_REALM_SPLIT"),
+            ServerEvent::SetDungeonDifficulty(_) => write!(f, "MSG_SET_DUNGEON_DIFFICULTY_Server"),
+            ServerEvent::StandStateUpdate(_) => write!(f, "SMSG_STANDSTATE_UPDATE"),
+            ServerEvent::TimeSyncReq(_) => write!(f, "SMSG_TIME_SYNC_REQ"),
+            ServerEvent::TransferPending(_) => write!(f, "SMSG_TRANSFER_PENDING"),
+            ServerEvent::TriggerCinematic(_) => write!(f, "SMSG_TRIGGER_CINEMATIC"),
+            ServerEvent::TutorialFlags(_) => write!(f, "SMSG_TUTORIAL_FLAGS"),
+            ServerEvent::UpdateAccountData(_) => write!(f, "SMSG_UPDATE_ACCOUNT_DATA"),
+            ServerEvent::UpdateAccountDataComplete(_) => write!(f, "SMSG_UPDATE_ACCOUNT_DATA_COMPLETE"),
+            ServerEvent::UpdateObject(_) => write!(f, "SMSG_UPDATE_OBJECT"),
+            ServerEvent::UpdateWorldState(_) => write!(f, "SMSG_UPDATE_WORLD_STATE"),
+            ServerEvent::WorldStateUiTimerUpdate(_) => write!(f, "SMSG_WORLD_STATE_UI_TIMER_UPDATE"),
+        }
+    }
+}
+
+pub trait IntoServerEvent {
+    fn into_server_event(self) -> ServerEvent;
+}
+
+impl IntoServerEvent for MSG_MOVE_START_FORWARD {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartForward(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_BACKWARD {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartBackward(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_STOP {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStop(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_STOP_TURN {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStopTurn(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_STRAFE_LEFT {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartStrafeLeft(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_STRAFE_RIGHT {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartStrafeRight(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_STOP_STRAFE {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStopStrafe(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_JUMP {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveJump(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_TURN_LEFT {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartTurnLeft(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_TURN_RIGHT {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartTurnRight(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_PITCH_UP {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartPitchUp(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_PITCH_DOWN {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartPitchDown(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_STOP_PITCH {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStopPitch(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_SET_RUN_MODE {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveSetRunMode(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_SET_WALK_MODE {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveSetWalkMode(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_FALL_LAND {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveFallLand(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_START_SWIM {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStartSwim(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_STOP_SWIM {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveStopSwim(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_SET_FACING {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveSetFacing(self)
+    }
+}
+
+impl IntoServerEvent for MSG_MOVE_HEARTBEAT {
+    fn into_server_event(self) -> ServerEvent {
+        ServerEvent::MoveHeartbeat(self)
+    }
+}
+
+/// Event multiplexing between client (socket) and server (manager) sides.
+#[allow(clippy::large_enum_variant)]
+pub enum ConnectionEvent {
+    /// Incoming message from the client to the server
+    Client(ClientOpcodeMessage),
+
+    /// Outgoing message from the server to the client
+    Server(ServerEvent),
+}

--- a/world_server/src/connection/mod.rs
+++ b/world_server/src/connection/mod.rs
@@ -1,0 +1,241 @@
+//! Per-socket network handler for the world server.
+//!
+//! - Owns the raw `TcpStream`, encryption/decryption state and minimal per-connection data.
+//! - Translates wire-level packets into higher-level `ClientEvent`s sent to the client manager;
+//!   the manager owns gameplay/session state so networking stays dumb and testable.
+//! - Uses a private `ServerEvent` channel so the manager can push outbound messages without
+//!   holding a mutable reference to the connection (improves isolation & concurrency).
+//! - Runs an event loop that races incoming client packets against manager-originated server
+//!   events to avoid head-of-line blocking (slow client writing does not delay server pushes).
+//! - Performs only the authentication handshake locally (seed + `CMSG_AUTH_SESSION`) because
+//!   the handshake needs immediate access to cryptographic material bound to the transport.
+//! - Keeps encryption halves optional until auth succeeds, making the state transition explicit.
+
+pub mod events;
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use smol::net::TcpStream;
+use tracing::*;
+use wow_srp::wrath_header::ProofSeed;
+use wow_srp::wrath_header::ServerDecrypterHalf;
+use wow_srp::wrath_header::ServerEncrypterHalf;
+use wow_world_messages::wrath::opcodes::ClientOpcodeMessage;
+use wow_world_messages::wrath::CMSG_AUTH_SESSION;
+use wow_world_messages::wrath::SMSG_AUTH_CHALLENGE;
+
+use wow_world_messages::wrath::astd_expect_client_message;
+use wrath_auth_db::AuthDatabase;
+
+use crate::handlers::handle_cmsg_auth_session;
+use crate::packet::ServerMessageExt;
+use events::{ClientEvent, ConnectionEvent, ServerEvent};
+
+pub struct ConnectionData {
+    pub account_id: Option<u32>,
+}
+
+/// Network connection wrapper; isolates socket, crypto state and messaging glue.
+pub struct Connection {
+    pub stream: TcpStream,
+    client_manager_sender: flume::Sender<ClientEvent>,
+
+    // Used to send events from the client manager to this connection
+    sender: flume::Sender<ServerEvent>,
+    receiver: flume::Receiver<ServerEvent>,
+
+    pub encryption: Option<ServerEncrypterHalf>,
+    decryption: Option<ServerDecrypterHalf>,
+
+    data: ConnectionData,
+}
+
+impl Connection {
+    /// Construct a new connection; creates an internal channel for manager-driven outbound events.
+    pub fn new(stream: TcpStream, client_manager_sender: flume::Sender<ClientEvent>) -> Self {
+        let (sender, receiver) = flume::unbounded();
+        Self {
+            stream,
+            client_manager_sender,
+            sender,
+            receiver,
+            encryption: None,
+            decryption: None,
+            data: ConnectionData { account_id: None },
+        }
+    }
+
+    /// Acquire a clone of the outbound server-event sender for registration with manager structures.
+    pub fn get_sender(&self) -> flume::Sender<ServerEvent> {
+        self.sender.clone()
+    }
+
+    /// Indicates whether the connection completed authentication (post `CMSG_AUTH_SESSION`).
+    pub fn is_authenticated(&self) -> bool {
+        self.data.account_id.is_some()
+    }
+
+    /// Install negotiated crypto; split halves allow send/recv to proceed independently.
+    pub fn set_crypto(&mut self, encryption: ServerEncrypterHalf, decryption: ServerDecrypterHalf) {
+        self.encryption.replace(encryption);
+        self.decryption.replace(decryption);
+    }
+
+    /// Gracefully terminate: inform the manager so it can clean up any retained session state.
+    pub async fn disconnect(&mut self) -> Result<()> {
+        let addr = self.stream.local_addr().unwrap();
+        info!("Disconnecting client {addr}");
+        // Let the client manager know that this client is disconnecting
+        self.client_manager_sender.send_async(ClientEvent::Disconnected { addr }).await?;
+        Ok(())
+    }
+
+    /// Entry point for a newly accepted socket: run handshake + bidirectional event loop + teardown.
+    pub async fn run(mut self, auth_db: Arc<AuthDatabase>) {
+        let addr = self.stream.local_addr().unwrap();
+        info!("New connection from {addr}");
+        if let Err(e) = self.update(auth_db).await {
+            error!("Error in client update {addr}: {e:?}");
+        }
+        self.disconnect().await.unwrap_or_else(|e| {
+            error!("Error disconnecting client {addr}: {e:?}");
+        });
+    }
+
+    /// Perform authentication then interleave reads from client and commands from manager until disconnect.
+    pub async fn update(&mut self, auth_db: Arc<AuthDatabase>) -> Result<()> {
+        // Authenticate first
+        let proof_seed = ProofSeed::new();
+        self.send_auth_challenge(&proof_seed).await?;
+
+        let auth_session_packet = astd_expect_client_message::<CMSG_AUTH_SESSION, _>(&mut self.stream).await?;
+
+        let account_id = handle_cmsg_auth_session(self, proof_seed, &auth_session_packet, auth_db).await?;
+
+        // Then, advertise the new connection to the client manager
+        let addr = self.stream.local_addr()?;
+        let connection_event = ClientEvent::Connected {
+            addr,
+            account_id,
+            connection_sender: self.sender.clone(),
+        };
+        self.client_manager_sender.send_async(connection_event).await?;
+
+        // Then race between receiving from the client and receiving from the manager
+        loop {
+            let event = smol::future::race(
+                receive_from_client(&mut self.stream, self.decryption.as_mut().unwrap()),
+                receive_from_manager(&self.receiver),
+            )
+            .await?;
+
+            match event {
+                ConnectionEvent::Client(packet) => {
+                    info!("Handling packet {packet} from client {addr}");
+                    let client_message = ClientEvent::Message { addr, packet };
+                    self.client_manager_sender.send_async(client_message).await?;
+                }
+                ConnectionEvent::Server(server_event) => {
+                    info!("Sending {server_event} from server to client {addr}");
+                    match server_event {
+                        ServerEvent::AccountDataTimes(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::ActionButtons(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::BindPointUpdate(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::CalendarSendNumPending(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::CharCreate(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::CharDelete(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::CharEnum(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::ContactList(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::DestroyObject(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::FeatureSystemStatus(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::ForceMoveRoot(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::ForceMoveUnroot(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::GMTicketGetTicket(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::GMTicketSystemStatus(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::InitialSpells(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::InitializeFactions(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::InitWorldStates(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::ItemNameQueryResponse(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::ItemQuerySingleResponse(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::LoginVerifyWorld(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::LoginSetTimeSpeed(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::LogoutComplete(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::LogoutCancelAck(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::LogoutResponse(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MessageChat(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveFallLand(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveHeartbeat(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveJump(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveSetFacing(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveSetRunMode(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveSetWalkMode(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartBackward(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartForward(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartPitchDown(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartPitchUp(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartStrafeLeft(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartStrafeRight(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStop(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartSwim(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartTurnLeft(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStartTurnRight(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStopPitch(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStopStrafe(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStopSwim(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveStopTurn(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::MoveTeleportAck(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::NameQueryResponse(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::NewWorld(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::PlayedTime(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::WorldStateUiTimerUpdate(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::QueryTimeResponse(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::Pong(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::RaidInstanceInfo(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::RealmSplit(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::SetDungeonDifficulty(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::StandStateUpdate(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::TimeSyncReq(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::TransferPending(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::TriggerCinematic(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::TutorialFlags(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::UpdateAccountDataComplete(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::UpdateAccountData(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::UpdateObject(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::UpdateWorldState(m) => m.astd_send_to_connection(self).await?,
+                        ServerEvent::Disconnect => {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Send initial auth challenge; seeds later key derivation and establishes crypto context.
+    pub async fn send_auth_challenge(&mut self, proof_seed: &ProofSeed) -> Result<()> {
+        use wow_world_messages::wrath::ServerMessage;
+        SMSG_AUTH_CHALLENGE {
+            unknown1: 1,
+            server_seed: proof_seed.seed(),
+            seed: [0_u8; 32],
+        }
+        .astd_write_unencrypted_server(&mut self.stream)
+        .await?;
+
+        Ok(())
+    }
+}
+
+/// Read & decrypt the next client packet; minimal framing logic kept near the transport boundary.
+async fn receive_from_client(stream: &mut TcpStream, decrypter: &mut ServerDecrypterHalf) -> Result<ConnectionEvent> {
+    let packet = ClientOpcodeMessage::astd_read_encrypted(stream, decrypter).await?;
+    Ok(ConnectionEvent::Client(packet))
+}
+
+/// Await the next manager-originated server event for this connection.
+async fn receive_from_manager(receiver: &flume::Receiver<ServerEvent>) -> Result<ConnectionEvent> {
+    Ok(ConnectionEvent::Server(receiver.recv_async().await?))
+}

--- a/world_server/src/connections.rs
+++ b/world_server/src/connections.rs
@@ -1,0 +1,53 @@
+//! Realm (world server) inbound connection acceptor.
+//!
+//! High-level design:
+//! - The world server listens for game client TCP connections whose public endpoint
+//!   (IP:port) is stored in the auth database; this lets operations change bind
+//!   addresses without rebuilding binaries or distributing config files.
+//! - `REALM_ID` (env var) selects the row in the auth DB so multiple realm
+//!   processes can share the same code and differ only by environment.
+//! - The accept loop is kept tiny: resolve bind address once, then continuously
+//!   accept and hand off each socket to a per-connection task.
+//! - Per-connection work is executed in detached async tasks so a slow or faulty
+//!   client never stalls accepting new ones.
+//! - A `flume::Sender<ClientEvent>` is cloned per connection to decouple raw IO
+//!   from higher-level session / game state management; this keeps the acceptor
+//!   ignorant of protocol details.
+//! - Public wrapper logs and swallows errors so a transient failure (e.g. DB
+//!   lookup race, ephemeral bind issue) does not panic the entire server.
+//!
+//! The goal is resilience and operational flexibility: configuration comes from
+//! the database, runtime failures are localized, and connection lifecycle logic
+//! remains isolated inside the `Connection` type / client manager elsewhere.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use smol::{net::TcpListener, stream::StreamExt};
+use tracing::error;
+use wrath_auth_db::AuthDatabase;
+
+use crate::connection::{events::ClientEvent, Connection};
+
+/// Public entry point that launches the realm connection accept loop and
+/// centralizes error reporting.
+pub async fn accept_realm_connections(auth_db: Arc<AuthDatabase>, client_manager_sender: flume::Sender<ClientEvent>) {
+    if let Err(e) = accept_realm_connections_impl(auth_db, client_manager_sender).await {
+        error!("Error in realm_socket::accept_realm_connections: {e:?}");
+    }
+}
+
+/// Internal implementation of the accept loop.
+async fn accept_realm_connections_impl(auth_db: Arc<AuthDatabase>, client_manager_sender: flume::Sender<ClientEvent>) -> Result<()> {
+    let realm_id: i32 = std::env::var("REALM_ID")?.parse()?;
+    let bind_ip = auth_db.get_realm_bind_ip(realm_id).await?;
+    let tcp_listener = TcpListener::bind(bind_ip).await?;
+    let mut incoming_connections = tcp_listener.incoming();
+
+    while let Some(tcp_stream) = incoming_connections.next().await {
+        let connection = Connection::new(tcp_stream?, client_manager_sender.clone());
+        smol::spawn(connection.run(auth_db.clone())).detach();
+    }
+
+    Ok(())
+}

--- a/world_server/src/handlers/bars_buttons_handler.rs
+++ b/world_server/src/handlers/bars_buttons_handler.rs
@@ -1,21 +1,33 @@
+use std::net::SocketAddr;
+
 use wow_world_messages::wrath::{ActionButton, CMSG_SET_ACTIONBAR_TOGGLES, CMSG_SET_ACTION_BUTTON};
 
+use crate::character::character_manager::CharacterManager;
 use crate::client_manager::ClientManager;
 use crate::prelude::*;
 
-pub async fn handle_csmg_set_actionbar_toggles(client_manager: &ClientManager, client_id: u64, packet: &CMSG_SET_ACTIONBAR_TOGGLES) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_csmg_set_actionbar_toggles(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_SET_ACTIONBAR_TOGGLES,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character = character_manager.get_character_mut(client.get_active_character())?;
     let action_bar = packet.action_bar;
 
-    let mut character = character_lock.write().await;
     character.set_visible_actionbar_mask(action_bar);
     Ok(())
 }
 
-pub async fn handle_cmsg_set_action_button(client_manager: &ClientManager, client_id: u64, packet: &CMSG_SET_ACTION_BUTTON) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_set_action_button(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_SET_ACTION_BUTTON,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character = character_manager.get_character_mut(client.get_active_character())?;
     let button_slot = packet.button;
     let action_button = ActionButton {
         action: packet.action,
@@ -23,7 +35,6 @@ pub async fn handle_cmsg_set_action_button(client_manager: &ClientManager, clien
         misc: packet.misc,
     };
 
-    let mut character = character_lock.write().await;
     character.set_action_bar_button(button_slot, action_button);
     Ok(())
 }

--- a/world_server/src/handlers/cinematics_handler.rs
+++ b/world_server/src/handlers/cinematics_handler.rs
@@ -1,28 +1,34 @@
-use crate::packet::ServerMessageExt;
+use std::net::SocketAddr;
+
+use crate::character::character_manager::CharacterManager;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
 use crate::{character::Character, client_manager::ClientManager};
 use wow_world_messages::wrath::{CinematicSequenceId, SMSG_TRIGGER_CINEMATIC};
 
 pub async fn send_trigger_cinematic(character: &Character, cinematic_id: CinematicSequenceId) -> Result<()> {
-    SMSG_TRIGGER_CINEMATIC {
+    let msg = SMSG_TRIGGER_CINEMATIC {
         cinematic_sequence_id: cinematic_id,
-    }
-    .astd_send_to_character(character)
-    .await
+    };
+    ServerEvent::TriggerCinematic(msg).send_to_character(character).await
 }
 
-pub async fn handle_csmg_next_cinematic_camera(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-
-    let mut character = character_lock.write().await;
+pub async fn handle_csmg_next_cinematic_camera(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character = character_manager.get_character_mut(client.get_active_character())?;
     character.handle_cinematic_next_camera()
 }
 
-pub async fn handle_csmg_complete_cinematic(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-
-    let mut character = character_lock.write().await;
+pub async fn handle_csmg_complete_cinematic(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character = character_manager.get_character_mut(client.get_active_character())?;
     character.handle_cinematic_ended()
 }

--- a/world_server/src/handlers/faction_handler.rs
+++ b/world_server/src/handlers/faction_handler.rs
@@ -1,5 +1,5 @@
 use crate::character::*;
-use crate::packet::*;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
 use wow_world_messages::wrath::FactionInitializer;
 use wow_world_messages::wrath::SMSG_INITIALIZE_FACTIONS;
@@ -8,5 +8,7 @@ const NUM_FACTIONS: u32 = 128;
 
 pub async fn send_faction_list(character: &Character) -> Result<()> {
     let factions = (0..NUM_FACTIONS).map(|_| FactionInitializer::default()).collect();
-    SMSG_INITIALIZE_FACTIONS { factions }.astd_send_to_character(character).await
+    ServerEvent::InitializeFactions(SMSG_INITIALIZE_FACTIONS { factions })
+        .send_to_character(character)
+        .await
 }

--- a/world_server/src/handlers/group_handler.rs
+++ b/world_server/src/handlers/group_handler.rs
@@ -1,9 +1,14 @@
+use std::net::SocketAddr;
+
 use wow_world_messages::wrath::SMSG_RAID_INSTANCE_INFO;
 
-use crate::{client_manager::ClientManager, packet::ServerMessageExt, prelude::*};
+use crate::{client_manager::ClientManager, connection::events::ServerEvent, prelude::*};
 
-pub async fn handle_cmsg_request_raid_info(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
+pub async fn handle_cmsg_request_raid_info(client_manager: &ClientManager, client_id: SocketAddr) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
 
-    SMSG_RAID_INSTANCE_INFO { raid_infos: vec![] }.astd_send_to_client(client).await
+    let msg = SMSG_RAID_INSTANCE_INFO { raid_infos: vec![] };
+    let event = ServerEvent::RaidInstanceInfo(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }

--- a/world_server/src/handlers/instance_handler.rs
+++ b/world_server/src/handlers/instance_handler.rs
@@ -1,15 +1,14 @@
-use crate::character::Character;
-use crate::packet::ServerMessageExt;
 use crate::prelude::*;
+use crate::{character::Character, connection::events::ServerEvent};
 
 use wow_world_messages::wrath::{DungeonDifficulty, MSG_SET_DUNGEON_DIFFICULTY_Server};
 
 pub async fn send_dungeon_difficulty(character: &Character) -> Result<()> {
-    MSG_SET_DUNGEON_DIFFICULTY_Server {
+    ServerEvent::SetDungeonDifficulty(MSG_SET_DUNGEON_DIFFICULTY_Server {
         difficulty: DungeonDifficulty::Normal,
         unknown1: 1,
         is_in_group: false,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }

--- a/world_server/src/handlers/login_handler.rs
+++ b/world_server/src/handlers/login_handler.rs
@@ -1,9 +1,12 @@
+use crate::character::character_manager::CharacterManager;
 use crate::character::Character;
-use crate::client::{Client, ClientState};
 use crate::client_manager::ClientManager;
+use crate::connection::events::ServerEvent;
+use crate::connection::Connection;
 use crate::packet::*;
 use crate::prelude::*;
 use podio::{LittleEndian, ReadPodExt};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use wow_srp::normalized_string::NormalizedString;
 use wow_srp::wrath_header::ProofSeed;
@@ -14,9 +17,14 @@ use wow_world_messages::wrath::{
 };
 use wrath_auth_db::AuthDatabase;
 
-pub async fn handle_cmsg_auth_session(client: &Client, proof_seed: ProofSeed, packet: &CMSG_AUTH_SESSION, auth_db: Arc<AuthDatabase>) -> Result<()> {
-    if client.is_authenticated().await {
-        client.disconnect().await?;
+pub async fn handle_cmsg_auth_session(
+    connection: &mut Connection,
+    proof_seed: ProofSeed,
+    packet: &CMSG_AUTH_SESSION,
+    auth_db: Arc<AuthDatabase>,
+) -> Result<u32> {
+    if connection.is_authenticated() {
+        connection.disconnect().await?;
         warn!("duplicate login rejected!");
         bail!("Client sent auth session but was already logged in");
     }
@@ -44,7 +52,7 @@ pub async fn handle_cmsg_auth_session(client: &Client, proof_seed: ProofSeed, pa
         SMSG_AUTH_RESPONSE {
             result: SMSG_AUTH_RESPONSE_WorldResult::AuthReject,
         }
-        .astd_send_to_client(client)
+        .astd_send_to_connection(connection)
         .await?;
 
         async_io::Timer::after(std::time::Duration::from_secs(2)).await;
@@ -54,10 +62,7 @@ pub async fn handle_cmsg_auth_session(client: &Client, proof_seed: ProofSeed, pa
     //Set the crypto of the client for use from now on
     {
         let (encrypt, decrypt) = client_encryption.unwrap().split();
-        let mut encryption = client.encryption.lock().await;
-        *encryption = Some(encrypt);
-        let mut decryption = client.decryption.lock().await;
-        *decryption = Some(decrypt);
+        connection.set_crypto(encrypt, decrypt);
     }
 
     SMSG_AUTH_RESPONSE {
@@ -68,7 +73,7 @@ pub async fn handle_cmsg_auth_session(client: &Client, proof_seed: ProofSeed, pa
             expansion: wow_world_messages::wrath::Expansion::WrathOfTheLichLing,
         },
     }
-    .astd_send_to_client(client)
+    .astd_send_to_connection(connection)
     .await?;
 
     //Handle full world queuing here
@@ -108,50 +113,48 @@ pub async fn handle_cmsg_auth_session(client: &Client, proof_seed: ProofSeed, pa
     //TODO: wow_world_messages needs changes to NOT write the size of the addon vec before writing
     //the addon vec, it corrupts the packet. Probably a skip-serialize tag that can be added to the
     //wowm file to the number_of_addons field to indicate the array size, but NOT write it into the final packet
-    SMSG_ADDON_INFO { addons }.astd_send_to_client(client).await?;
-    SMSG_CLIENTCACHE_VERSION { version: 0 }.astd_send_to_client(client).await?;
+    SMSG_ADDON_INFO { addons }.astd_send_to_connection(connection).await?;
+    SMSG_CLIENTCACHE_VERSION { version: 0 }.astd_send_to_connection(connection).await?;
 
-    send_tutorial_flags(client).await?;
+    send_tutorial_flags(connection).await?;
 
-    let mut client_data = client.data.write().await;
-    client_data.client_state = ClientState::CharacterSelection;
-    client_data.account_id = Some(db_account.id);
-
-    Ok(())
+    Ok(db_account.id)
 }
 
-async fn send_tutorial_flags(client: &Client) -> Result<()> {
-    SMSG_TUTORIAL_FLAGS { tutorial_data: [0; 8] }.astd_send_to_client(client).await
+async fn send_tutorial_flags(connection: &mut Connection) -> Result<()> {
+    SMSG_TUTORIAL_FLAGS { tutorial_data: [0; 8] }.astd_send_to_connection(connection).await
 }
 
-pub async fn handle_cmsg_realm_split(client_manager: &ClientManager, client_id: u64, packet: &CMSG_REALM_SPLIT) -> Result<()> {
-    let client = client_manager.get_client(client_id).await?;
-    SMSG_REALM_SPLIT {
+pub async fn handle_cmsg_realm_split(client_manager: &ClientManager, client_id: SocketAddr, packet: &CMSG_REALM_SPLIT) -> Result<()> {
+    let client = client_manager.get_client(client_id)?;
+    let msg = SMSG_REALM_SPLIT {
         realm_id: packet.realm_id,
         state: RealmSplitState::Normal,
         split_date: "01/01/01".into(),
-    }
-    .astd_send_to_client(client)
-    .await
+    };
+    let server_event = ServerEvent::RealmSplit(msg);
+    client.connection_sender.send_async(server_event).await?;
+    Ok(())
 }
 
-pub async fn handle_cmsg_ping(client_manager: &ClientManager, client_id: u64, packet: &CMSG_PING) -> Result<()> {
-    let client = client_manager.get_client(client_id).await?;
-    SMSG_PONG {
+pub async fn handle_cmsg_ping(client_manager: &ClientManager, client_id: SocketAddr, packet: &CMSG_PING) -> Result<()> {
+    let client = client_manager.get_client(client_id)?;
+    let msg = SMSG_PONG {
         sequence_id: packet.sequence_id,
-    }
-    .astd_send_to_client(client)
-    .await
+    };
+    let event = ServerEvent::Pong(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
 pub async fn send_login_set_time_speed(character: &Character) -> Result<()> {
-    SMSG_LOGIN_SETTIMESPEED {
+    ServerEvent::LoginSetTimeSpeed(SMSG_LOGIN_SETTIMESPEED {
         //TODO: Use chrono for this, removed because of trait not satisfied
         datetime: wow_world_messages::DateTime::new(23, wow_world_messages::Month::July, 15, wow_world_messages::Weekday::Saturday, 12, 12),
         timescale: 0.01667f32,
         unknown1: 0,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
@@ -163,26 +166,38 @@ pub enum LogoutState {
     ReturnToCharSelect,
 }
 
-pub async fn handle_cmsg_logout_request(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
+pub async fn handle_cmsg_logout_request(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
 
     let (result, speed) = {
-        let character_lock = client.get_active_character().await?;
-        let mut character = character_lock.write().await;
+        let character = character_manager.get_character_mut(client.get_active_character())?;
         character.try_logout().await?
     };
 
-    SMSG_LOGOUT_RESPONSE { result, speed }.astd_send_to_client(client).await
+    let msg = SMSG_LOGOUT_RESPONSE { result, speed };
+    let event = ServerEvent::LogoutResponse(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
-pub async fn handle_cmsg_logout_cancel(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-    let mut character = character_lock.write().await;
+pub async fn handle_cmsg_logout_cancel(
+    client_manager: &mut ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character = character_manager.get_character_mut(client.get_active_character())?;
     character.cancel_logout().await?;
-    SMSG_LOGOUT_CANCEL_ACK {}.astd_send_to_client(client).await
+    let msg = SMSG_LOGOUT_CANCEL_ACK {};
+    let event = ServerEvent::LogoutCancelAck(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
 pub async fn send_smsg_logout_complete(character: &Character) -> Result<()> {
-    SMSG_LOGOUT_COMPLETE {}.astd_send_to_character(character).await
+    ServerEvent::LogoutComplete(SMSG_LOGOUT_COMPLETE {}).send_to_character(character).await
 }

--- a/world_server/src/handlers/mod.rs
+++ b/world_server/src/handlers/mod.rs
@@ -24,6 +24,7 @@ pub use character_handler::handle_cmsg_char_create;
 pub use character_handler::handle_cmsg_char_delete;
 pub use character_handler::handle_cmsg_char_enum;
 pub use character_handler::handle_cmsg_player_login;
+pub use character_handler::handle_cmsg_player_logout;
 pub use character_handler::handle_cmsg_standstate_change;
 pub use character_handler::handle_cmsg_swap_inv_item;
 pub use character_handler::send_action_buttons;
@@ -71,7 +72,7 @@ pub use social_handler::handle_cmsg_calendar_get_num_pending;
 pub use social_handler::handle_cmsg_contact_list;
 pub use social_handler::handle_cmsg_join_channel;
 pub use social_handler::handle_cmsg_messagechat;
-pub use social_handler::handle_csmg_set_selection;
+pub use social_handler::handle_cmsg_set_selection;
 pub use social_handler::send_contact_list;
 
 mod queries_handler;

--- a/world_server/src/handlers/movement_handler.rs
+++ b/world_server/src/handlers/movement_handler.rs
@@ -1,12 +1,12 @@
+use crate::character::character_manager::CharacterManager;
 use crate::character::Character;
 use crate::client_manager::ClientManager;
+use crate::connection::events::{IntoServerEvent, ServerEvent};
 use crate::data::{AreaTriggerPurpose, PositionAndOrientation, WorldZoneLocation};
-use crate::packet::ServerMessageExt;
 use crate::prelude::*;
 use crate::world::prelude::GameObject;
 use crate::world::World;
-use smol::lock::RwLockUpgradableReadGuard;
-use std::sync::Arc;
+use std::net::SocketAddr;
 use wow_world_messages::wrath::{
     Area, ClientMessage, MSG_MOVE_TELEPORT_ACK_Client, MSG_MOVE_TELEPORT_ACK_Server, Map, MovementInfo, ServerMessage, UnitStandState, Vector3d,
     CMSG_AREATRIGGER, CMSG_SET_ACTIVE_MOVER, CMSG_WORLD_TELEPORT, MSG_MOVE_FALL_LAND, MSG_MOVE_HEARTBEAT, MSG_MOVE_JUMP, MSG_MOVE_SET_FACING,
@@ -16,7 +16,7 @@ use wow_world_messages::wrath::{
     SMSG_FORCE_MOVE_ROOT, SMSG_FORCE_MOVE_UNROOT, SMSG_NEW_WORLD, SMSG_STANDSTATE_UPDATE, SMSG_TRANSFER_PENDING,
 };
 
-pub trait MovementMessage: Sync + ServerMessage + ClientMessage {
+pub trait MovementMessage: Sync + ServerMessage + ClientMessage + IntoServerEvent {
     fn get_guid(&self) -> Guid;
     fn get_movement_info(&self) -> MovementInfo;
 }
@@ -56,27 +56,33 @@ define_movement_packet!(MSG_MOVE_STOP_SWIM);
 define_movement_packet!(MSG_MOVE_SET_FACING);
 define_movement_packet!(MSG_MOVE_HEARTBEAT);
 
-pub async fn handle_movement_generic<T: MovementMessage>(client_manager: &ClientManager, client_id: u64, world: &World, packet: T) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_movement_generic<T: MovementMessage>(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    world: &World,
+    packet: T,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
     {
-        let character = character_lock.read().await;
+        let character = character_manager.get_character_mut(guid)?;
         if character.teleportation_state != TeleportationState::None {
             //Not an error, but we do simply want to ignore these packet
             return Ok(());
         }
-    }
 
-    let _guid = packet.get_guid();
-    let movement_info = packet.get_movement_info();
+        let _guid = packet.get_guid();
+        let movement_info = packet.get_movement_info();
 
-    {
-        let mut character = character_lock.write().await;
         character.process_movement(movement_info);
     }
 
-    let character = character_lock.read().await;
-    packet.astd_send_to_all_in_range(&*character, false, world).await
+    let character = character_manager.get_character(guid)?;
+    packet
+        .into_server_event()
+        .send_to_all_in_range(character, character_manager, false, world)
+        .await
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -97,36 +103,42 @@ pub async fn send_msg_move_teleport_ack(character: &Character, destination: &Pos
     movement_info.position = destination.position;
     movement_info.orientation = destination.orientation;
 
-    MSG_MOVE_TELEPORT_ACK_Server {
+    ServerEvent::MoveTeleportAck(MSG_MOVE_TELEPORT_ACK_Server {
         guid: character.get_guid(),
         movement_counter: 0, //TODO: Value should increment with every teleport?
         info: movement_info,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
 pub async fn send_smsg_transfer_pending(character: &Character, map: Map) -> Result<()> {
-    SMSG_TRANSFER_PENDING { map, has_transport: None }.astd_send_to_character(character).await
+    ServerEvent::TransferPending(SMSG_TRANSFER_PENDING { map, has_transport: None })
+        .send_to_character(character)
+        .await
 }
 
 pub async fn send_smsg_new_world(character: &Character, map: Map, position: PositionAndOrientation) -> Result<()> {
-    SMSG_NEW_WORLD {
+    ServerEvent::NewWorld(SMSG_NEW_WORLD {
         map,
         position: position.position,
         orientation: position.orientation,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
-pub async fn handle_msg_move_teleport_ack(client_manager: &ClientManager, client_id: u64, _packet: &MSG_MOVE_TELEPORT_ACK_Client) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-    let character = character_lock.upgradable_read().await;
+pub async fn handle_msg_move_teleport_ack(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    _packet: &MSG_MOVE_TELEPORT_ACK_Client,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character_mut(guid)?;
 
     if let TeleportationState::Executing(TeleportationDistance::Near(destination)) = character.teleportation_state.clone() {
-        let mut character = RwLockUpgradableReadGuard::upgrade(character).await;
         character.set_position(&destination);
         character.teleportation_state = TeleportationState::None;
     }
@@ -134,32 +146,57 @@ pub async fn handle_msg_move_teleport_ack(client_manager: &ClientManager, client
     Ok(())
 }
 
-pub async fn handle_msg_move_worldport_ack(client_manager: &ClientManager, client_id: u64, world: &World) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-    let character = character_lock.upgradable_read().await;
+pub async fn handle_msg_move_worldport_ack(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    world: &mut World,
+) -> Result<()> {
+    let teleportation_state = {
+        let client = client_manager.get_authenticated_client(client_id)?;
+        let guid = client.get_active_character();
+        let character = character_manager.get_character_mut(guid)?;
+        character.teleportation_state.clone()
+    };
 
-    if let TeleportationState::Executing(TeleportationDistance::Far(destination)) = character.teleportation_state.clone() {
-        let mut character = RwLockUpgradableReadGuard::upgrade(character).await;
-        let map = world.get_instance_manager().get_or_create_map(&(*character), destination.map).await?;
+    if let TeleportationState::Executing(TeleportationDistance::Far(destination)) = teleportation_state {
+        let map = destination.map;
+        {
+            let guid = client_manager.get_character_from_client(client_id).await?;
+            let character = character_manager.get_character_mut(guid)?;
+            let _ = world.get_instance_manager_mut().get_or_create_map(character, map).await?;
+            character.map = map;
+            character.set_position(&destination.into());
+            character.reset_time_sync();
+        }
 
-        character.map = destination.map;
-        character.set_position(&destination.into());
-        character.reset_time_sync();
+        let client = client_manager.get_authenticated_client(client_id)?;
+        let guid = client.get_active_character();
+        let character = character_manager.get_character(guid)?;
         character.send_packets_before_add_to_map().await?;
-        map.push_object(Arc::downgrade(&character_lock)).await;
-        character.send_packets_after_add_to_map(world.get_realm_database()).await?;
 
-        character.teleportation_state = TeleportationState::None;
+        let map = world.get_instance_manager_mut().get_or_create_map(character, map).await?;
+        map.push_character(character);
+        character.send_packets_after_add_to_map(world.get_realm_database()).await?;
+        {
+            let guid = client_manager.get_character_from_client(client_id).await?;
+            let character = character_manager.get_character_mut(guid)?;
+            character.teleportation_state = TeleportationState::None;
+        }
     }
 
     Ok(())
 }
 
-pub async fn handle_msg_world_teleport(client_manager: &ClientManager, client_id: u64, packet: &CMSG_WORLD_TELEPORT) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-    let mut character = character_lock.write().await;
+pub async fn handle_msg_world_teleport(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_WORLD_TELEPORT,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character_mut(guid)?;
 
     info!("Teleporting character {} to {} ({:?})", character.name, packet.map, packet.position);
 
@@ -175,51 +212,54 @@ pub async fn handle_msg_world_teleport(client_manager: &ClientManager, client_id
 }
 
 pub async fn send_smsg_stand_state_update(character: &Character, stand_state: UnitStandState) -> Result<()> {
-    SMSG_STANDSTATE_UPDATE { state: stand_state }.astd_send_to_character(character).await
+    ServerEvent::StandStateUpdate(SMSG_STANDSTATE_UPDATE { state: stand_state })
+        .send_to_character(character)
+        .await
 }
 
 pub async fn send_smsg_force_move_root(character: &Character) -> Result<()> {
-    SMSG_FORCE_MOVE_ROOT {
+    ServerEvent::ForceMoveRoot(SMSG_FORCE_MOVE_ROOT {
         guid: character.get_guid(),
         counter: 0,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
 pub async fn send_smsg_force_move_unroot(character: &Character) -> Result<()> {
-    SMSG_FORCE_MOVE_UNROOT {
+    ServerEvent::ForceMoveUnroot(SMSG_FORCE_MOVE_UNROOT {
         guid: character.get_guid(),
         counter: 0,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
-pub async fn handle_cmsg_set_active_mover(client_manager: &ClientManager, client_id: u64, packet: &CMSG_SET_ACTIVE_MOVER) -> Result<()> {
+pub async fn handle_cmsg_set_active_mover(client_manager: &ClientManager, client_id: SocketAddr, packet: &CMSG_SET_ACTIVE_MOVER) -> Result<()> {
     //Many other emulators only do some verification upon receiving this packet.
     //Maybe it doesn't serve any other purpose but to have the server check it's content
     //but I have a feeling the actual server does more with this...
 
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-    let character = character_lock.read().await;
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character_guid = client.get_active_character();
 
     let mover_guid = packet.guid;
     //TODO: check against the character->mover, but since moving anything other than the character
     //itself (e.g. mind control) isn't implemented yet, we expect the character guid.
     //This warning will be false negative once stuff like mindcontrol is implemented, and must be
     //fixed then.
-    if character.get_guid() != mover_guid {
+    if character_guid != mover_guid {
         warn!("Unexpected mover guid sent by the client");
     }
     Ok(())
 }
 
-pub async fn handle_cmsg_areatrigger(client_manager: &ClientManager, client_id: u64, packet: &CMSG_AREATRIGGER) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-
+pub async fn handle_cmsg_areatrigger(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_AREATRIGGER,
+) -> Result<()> {
     let area_trigger_id = packet.trigger_id;
 
     let trigger_data = client_manager
@@ -228,7 +268,6 @@ pub async fn handle_cmsg_areatrigger(client_manager: &ClientManager, client_id: 
         .ok_or_else(|| anyhow!("Character entered area trigger that isn't known to the server"))?;
 
     if let AreaTriggerPurpose::Teleport(teleport_data) = &trigger_data.purpose {
-        let mut character = character_lock.write().await;
         let destination = WorldZoneLocation {
             position: Vector3d {
                 x: teleport_data.target_position_x,
@@ -239,9 +278,13 @@ pub async fn handle_cmsg_areatrigger(client_manager: &ClientManager, client_id: 
             map: (teleport_data.target_map as u32).try_into()?,
             area: Area::NorthshireValley, //TODO
         };
+
+        let client = client_manager.get_authenticated_client(client_id)?;
+        let character = character_manager.get_character_mut(client.get_active_character())?;
         character.teleport_to(TeleportationDistance::Far(destination))
     } else if let AreaTriggerPurpose::RestedArea = &trigger_data.purpose {
-        let mut character = character_lock.write().await;
+        let client = client_manager.get_authenticated_client(client_id)?;
+        let character = character_manager.get_character_mut(client.get_active_character())?;
         character.handle_enter_inn()?;
     }
     Ok(())

--- a/world_server/src/handlers/queries_handler.rs
+++ b/world_server/src/handlers/queries_handler.rs
@@ -1,22 +1,29 @@
+use crate::character::character_manager::CharacterManager;
 use crate::client::Client;
 use crate::client_manager::ClientManager;
-use crate::packet::*;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
 use crate::world::World;
 use crate::{character::Character, world::prelude::GameObject};
+use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 use wow_world_messages::wrath::{
     CMSG_ITEM_NAME_QUERY, CMSG_ITEM_QUERY_SINGLE, CMSG_NAME_QUERY, CMSG_PLAYED_TIME, SMSG_ITEM_QUERY_SINGLE_RESPONSE, SMSG_NAME_QUERY_RESPONSE,
     SMSG_PLAYED_TIME, SMSG_QUERY_TIME_RESPONSE, SMSG_WORLD_STATE_UI_TIMER_UPDATE,
 };
 
-pub async fn handle_cmsg_played_time(client_manager: &ClientManager, client_id: u64, packet: &CMSG_PLAYED_TIME) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_played_time(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_PLAYED_TIME,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character_mut(guid)?;
 
     let (total_played_time, level_played_time) = {
         let unix_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as u32;
-        let mut character = character_lock.write().await;
         let delta_seconds = unix_time - character.last_playtime_calculation_timestamp;
         character.seconds_played_total += delta_seconds;
         character.seconds_played_at_level += delta_seconds;
@@ -24,57 +31,65 @@ pub async fn handle_cmsg_played_time(client_manager: &ClientManager, client_id: 
         (character.seconds_played_total, character.seconds_played_at_level)
     };
 
-    SMSG_PLAYED_TIME {
+    let msg = SMSG_PLAYED_TIME {
         total_played_time,
         level_played_time,
         show_on_ui: packet.show_on_ui,
-    }
-    .astd_send_to_client(client)
-    .await
+    };
+    let event = ServerEvent::PlayedTime(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
-pub async fn handle_cmsg_query_time(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_client(client_id).await?;
+pub async fn handle_cmsg_query_time(client_manager: &ClientManager, client_id: SocketAddr) -> Result<()> {
+    let client = client_manager.get_client(client_id)?;
     let unix_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as u32;
-    SMSG_QUERY_TIME_RESPONSE {
+    let msg = SMSG_QUERY_TIME_RESPONSE {
         time: unix_time,
         time_until_daily_quest_reset: 0,
-    }
-    .astd_send_to_client(client)
-    .await
+    };
+    let event = ServerEvent::QueryTimeResponse(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
-pub async fn handle_cmsg_world_state_ui_timer_update(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_client(client_id).await?;
+pub async fn handle_cmsg_world_state_ui_timer_update(client_manager: &ClientManager, client_id: SocketAddr) -> Result<()> {
+    let client = client_manager.get_client(client_id)?;
     let unix_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as u32;
-    SMSG_WORLD_STATE_UI_TIMER_UPDATE { time: unix_time }.astd_send_to_client(client).await
+    let msg = SMSG_WORLD_STATE_UI_TIMER_UPDATE { time: unix_time };
+    let event = ServerEvent::WorldStateUiTimerUpdate(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
-pub async fn handle_cmsg_name_query(client_manager: &ClientManager, client_id: u64, world: &World, packet: &CMSG_NAME_QUERY) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_name_query(
+    client_manager: &ClientManager,
+    character_manager: &CharacterManager,
+    client_id: SocketAddr,
+    world: &World,
+    packet: &CMSG_NAME_QUERY,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character(guid)?;
 
     //Stop early if we are requesting our own information
-    let character = character_lock.read().await;
     if character.get_guid() == packet.guid {
-        return send_name_query_response(&client, &character).await;
+        return send_name_query_response(client, character).await;
     }
 
     //We are requesting somebody else. Search the map
-    if let Some(map) = world.get_instance_manager().try_get_map_for_character(&character).await {
-        if let Some(found_character_lock) = map.try_get_object(packet.guid).await.and_then(|a| a.upgrade()) {
-            if let Some(found_character) = found_character_lock.read().await.as_character() {
-                send_name_query_response(&client, found_character).await?;
-            } else {
-                bail!("There was a cmsg_name_query for a found object, but it was not a character");
-            }
+    if let Some(map) = world.get_instance_manager().try_get_map_for_character(character) {
+        if map.find_character(packet.guid) {
+            let found_character = character_manager.get_character(packet.guid)?;
+            send_name_query_response(client, found_character).await?;
         } else {
             //This character is not on the same map as whoever requested it, so we do a lookup via
             //the client manager.
-            if let Some(found_client) = client_manager.find_client_from_active_character_guid(&packet.guid).await? {
-                let char_lock = found_client.get_active_character().await?;
-                let active_character = char_lock.read().await;
-                send_name_query_response(&client, &active_character).await?;
+            if let Ok(found_client) = client_manager.find_client_from_active_character_guid(packet.guid) {
+                let guid = found_client.get_active_character();
+                let character = character_manager.get_character(guid)?;
+                send_name_query_response(client, character).await?;
             }
         }
     } else {
@@ -84,7 +99,7 @@ pub async fn handle_cmsg_name_query(client_manager: &ClientManager, client_id: u
 }
 
 async fn send_name_query_response(receiver: &Client, target_character: &Character) -> Result<()> {
-    SMSG_NAME_QUERY_RESPONSE {
+    let msg = SMSG_NAME_QUERY_RESPONSE {
         guid: target_character.get_guid(),
         character_name: target_character.name.clone(),
         realm_name: String::new(),
@@ -92,47 +107,48 @@ async fn send_name_query_response(receiver: &Client, target_character: &Characte
         class: target_character.get_class(),
         gender: target_character.get_gender(),
         has_declined_names: wow_world_messages::wrath::SMSG_NAME_QUERY_RESPONSE_DeclinedNames::No,
-    }
-    .astd_send_to_client(receiver)
-    .await
+    };
+    let event = ServerEvent::NameQueryResponse(msg);
+    receiver.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
 pub async fn handle_cmsg_item_query_single(
     client_manager: &ClientManager,
-    client_id: u64,
+    client_id: SocketAddr,
     _world: &World,
     packet: &CMSG_ITEM_QUERY_SINGLE,
 ) -> Result<()> {
-    let client = client_manager.get_client(client_id).await?;
+    let client = client_manager.get_client(client_id)?;
     //TODO: use DB to lookup
     let item = wow_items::wrath::lookup_item(packet.item);
-    match item {
-        None => {
-            SMSG_ITEM_QUERY_SINGLE_RESPONSE {
-                item: packet.item | 0x80000000,
-                found: None,
-            }
-            .astd_send_to_client(client)
-            .await
-        }
-        Some(item) => wow_world_messages::wrath::item_to_query_response(item).astd_send_to_client(client).await,
-    }
+    let msg = match item {
+        None => SMSG_ITEM_QUERY_SINGLE_RESPONSE {
+            item: packet.item | 0x80000000,
+            found: None,
+        },
+        Some(item) => wow_world_messages::wrath::item_to_query_response(item),
+    };
+    let event = ServerEvent::ItemQuerySingleResponse(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
 pub async fn handle_cmsg_item_name_query(
     client_manager: &ClientManager,
-    client_id: u64,
+    client_id: SocketAddr,
     _world: &World,
     packet: &CMSG_ITEM_NAME_QUERY,
 ) -> Result<()> {
     //TODO: use DB to lookup
     let item = wow_items::wrath::lookup_item(packet.item);
-    let client = client_manager.get_client(client_id).await?;
+    let client = client_manager.get_client(client_id)?;
     match item {
         Some(item) => {
-            wow_world_messages::wrath::item_to_name_query_response(item)
-                .astd_send_to_client(client)
-                .await
+            let msg = wow_world_messages::wrath::item_to_name_query_response(item);
+            let event = ServerEvent::ItemNameQueryResponse(msg);
+            client.connection_sender.send_async(event).await?;
+            Ok(())
         }
         None => Err(anyhow!("Item {} not found for client {}", packet.item, client_id)),
     }

--- a/world_server/src/handlers/social_handler.rs
+++ b/world_server/src/handlers/social_handler.rs
@@ -1,4 +1,7 @@
-use crate::packet::ServerMessageExt;
+use std::net::SocketAddr;
+
+use crate::character::character_manager::CharacterManager;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
 use crate::world::prelude::GameObject;
 use crate::world::World;
@@ -10,57 +13,77 @@ use wow_world_messages::wrath::{
     SMSG_CALENDAR_SEND_NUM_PENDING, SMSG_CONTACT_LIST, SMSG_MESSAGECHAT,
 };
 
-pub async fn handle_cmsg_contact_list(client_manager: &ClientManager, client_id: u64, packet: &CMSG_CONTACT_LIST) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_contact_list(
+    client_manager: &ClientManager,
+    character_manager: &CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_CONTACT_LIST,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character(guid)?;
 
     let requested_social_mask = RelationType::new(packet.flags);
-    let character = character_lock.write().await;
-    send_contact_list(&character, requested_social_mask).await
+    send_contact_list(character, requested_social_mask).await
 }
 
-pub async fn handle_cmsg_calendar_get_num_pending(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    SMSG_CALENDAR_SEND_NUM_PENDING { pending_events: 0 }.astd_send_to_client(client).await
+pub async fn handle_cmsg_calendar_get_num_pending(client_manager: &ClientManager, client_id: SocketAddr) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let msg = SMSG_CALENDAR_SEND_NUM_PENDING { pending_events: 0 };
+    let event = ServerEvent::CalendarSendNumPending(msg);
+    client.connection_sender.send_async(event).await?;
+    Ok(())
 }
 
 pub async fn send_contact_list(character: &Character, relation_mask: RelationType) -> Result<()> {
-    SMSG_CONTACT_LIST {
+    let msg = SMSG_CONTACT_LIST {
         list_mask: relation_mask,
         relations: vec![],
-    }
-    .astd_send_to_character(character)
-    .await
+    };
+    ServerEvent::ContactList(msg).send_to_character(character).await
 }
 
-pub async fn handle_csmg_set_selection(client_manager: &ClientManager, client_id: u64, packet: &CMSG_SET_SELECTION) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_set_selection(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_SET_SELECTION,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character_mut(guid)?;
 
-    let mut character = character_lock.write().await;
     let selection = if packet.target.is_zero() { None } else { Some(packet.target) };
     character.set_selection(selection);
     Ok(())
 }
 
-pub async fn handle_cmsg_join_channel(client_manager: &ClientManager, client_id: u64, _packet: &CMSG_JOIN_CHANNEL) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let _character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_join_channel(client_manager: &ClientManager, client_id: SocketAddr, _packet: &CMSG_JOIN_CHANNEL) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let _character = client.get_active_character();
 
     //There are no chat systems yet. This packet is "handled" to silence the warning spam
     Ok(())
 }
 
-pub async fn handle_cmsg_messagechat(client_manager: &ClientManager, world: &World, client_id: u64, packet: &CMSG_MESSAGECHAT) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-    let character = character_lock.read().await;
+pub async fn handle_cmsg_messagechat(
+    client_manager: &ClientManager,
+    character_manager: &CharacterManager,
+    world: &World,
+    client_id: SocketAddr,
+    packet: &CMSG_MESSAGECHAT,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character(guid)?;
 
     match &packet.chat_type {
         CMSG_MESSAGECHAT_ChatType::Say | CMSG_MESSAGECHAT_ChatType::Yell | CMSG_MESSAGECHAT_ChatType::Emote => {
-            handle_world_proximity_message(&character, world, packet).await?
+            handle_world_proximity_message(character, character_manager, world, packet).await?
         }
-        CMSG_MESSAGECHAT_ChatType::Whisper { target_player } => handle_whisper(&character, target_player, client_manager, packet).await?,
+        CMSG_MESSAGECHAT_ChatType::Whisper { target_player } => {
+            handle_whisper(character, target_player, client_manager, character_manager, packet).await?
+        }
         _ => todo!(),
     };
 
@@ -68,7 +91,12 @@ pub async fn handle_cmsg_messagechat(client_manager: &ClientManager, world: &Wor
 }
 
 //Chat messages that are meant to arrive to people nearby.
-async fn handle_world_proximity_message(sender: &Character, world: &World, packet: &CMSG_MESSAGECHAT) -> Result<()> {
+async fn handle_world_proximity_message(
+    sender: &Character,
+    character_manager: &CharacterManager,
+    world: &World,
+    packet: &CMSG_MESSAGECHAT,
+) -> Result<()> {
     let chat_type = match packet.chat_type {
         CMSG_MESSAGECHAT_ChatType::Say => SMSG_MESSAGECHAT_ChatType::Say { target6: sender.get_guid() },
         CMSG_MESSAGECHAT_ChatType::Yell => SMSG_MESSAGECHAT_ChatType::Yell { target6: sender.get_guid() },
@@ -78,46 +106,53 @@ async fn handle_world_proximity_message(sender: &Character, world: &World, packe
 
     let tag = PlayerChatTag::None;
 
-    SMSG_MESSAGECHAT {
+    ServerEvent::MessageChat(SMSG_MESSAGECHAT {
         chat_type,
         language: packet.language,
         sender: sender.get_guid(),
         flags: 0,
         message: packet.message.clone(),
         tag,
-    }
-    .astd_send_to_all_in_range(sender, true, world)
+    })
+    .send_to_all_in_range(sender, character_manager, true, world)
     .await
 }
 
-async fn handle_whisper(sender: &Character, receiver_name: &str, client_manager: &ClientManager, packet: &CMSG_MESSAGECHAT) -> Result<()> {
+async fn handle_whisper(
+    sender: &Character,
+    receiver_name: &str,
+    client_manager: &ClientManager,
+    character_manager: &CharacterManager,
+    packet: &CMSG_MESSAGECHAT,
+) -> Result<()> {
     assert!(std::matches!(packet.chat_type, CMSG_MESSAGECHAT_ChatType::Whisper { .. }));
 
-    if let Some(receiving_client) = client_manager.find_client_from_active_character_name(receiver_name).await? {
+    if let Ok(receiving_client) = client_manager.find_client_from_active_character_name(receiver_name, character_manager) {
         let chat_type = SMSG_MESSAGECHAT_ChatType::Whisper { target6: sender.get_guid() };
         let tag = PlayerChatTag::None;
 
-        SMSG_MESSAGECHAT {
+        let msg = SMSG_MESSAGECHAT {
             chat_type,
             language: packet.language,
             sender: sender.get_guid(),
             flags: 0,
             message: packet.message.clone(),
             tag,
-        }
-        .astd_send_to_client(receiving_client)
-        .await?;
+        };
+        let event = ServerEvent::MessageChat(msg);
+        receiving_client.connection_sender.send_async(event).await?;
     } else {
-        SMSG_MESSAGECHAT {
+        let msg = SMSG_MESSAGECHAT {
             chat_type: SMSG_MESSAGECHAT_ChatType::System { target6: sender.get_guid() },
             language: wow_world_base::wrath::Language::Universal,
             sender: sender.get_guid(),
             flags: 0,
             message: "No player by that name".to_string(),
             tag: PlayerChatTag::None,
-        }
-        .astd_send_to_character(sender)
-        .await?;
+        };
+        let event = ServerEvent::MessageChat(msg);
+        let client = client_manager.find_client_from_active_character_guid(sender.get_guid())?;
+        client.connection_sender.send_async(event).await?;
     }
     Ok(())
 }

--- a/world_server/src/handlers/tutorial_handler.rs
+++ b/world_server/src/handlers/tutorial_handler.rs
@@ -1,34 +1,46 @@
+use std::net::SocketAddr;
+
+use crate::character::{character_manager::CharacterManager, *};
 use crate::client_manager::ClientManager;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
-use crate::{character::*, packet::ServerMessageExt};
 use bit_field::BitArray;
-use wow_world_messages::wrath::CMSG_TUTORIAL_FLAG;
+use wow_world_messages::wrath::{CMSG_TUTORIAL_FLAG, SMSG_TUTORIAL_FLAGS};
 
 pub async fn send_tutorial_flags(character: &Character) -> Result<()> {
-    wow_world_messages::wrath::SMSG_TUTORIAL_FLAGS {
+    ServerEvent::TutorialFlags(SMSG_TUTORIAL_FLAGS {
         tutorial_data: character.tutorial_flags.flag_data,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
-pub async fn handle_cmsg_tutorial_flag(client_manager: &ClientManager, client_id: u64, packet: &CMSG_TUTORIAL_FLAG) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_tutorial_flag(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_TUTORIAL_FLAG,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let character = client.get_active_character();
+    let character = character_manager.get_character_mut(character)?;
 
     let tut_flag_index = packet.tutorial_flag as usize;
 
-    let mut character = character_lock.write().await;
     character.tutorial_flags.set_bit(tut_flag_index, true);
     trace!("Handled tutorial flag, flags are now: {:?}", character.tutorial_flags.flag_data);
     Ok(())
 }
 
-pub async fn handle_cmsg_tutorial_reset(client_manager: &ClientManager, client_id: u64) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_tutorial_reset(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character_mut(guid)?;
 
-    let mut character = character_lock.write().await;
     character.tutorial_flags.reset();
     trace!("Reset all tutorials for: {}", character.name);
     Ok(())

--- a/world_server/src/handlers/voice_chat_handler.rs
+++ b/world_server/src/handlers/voice_chat_handler.rs
@@ -1,12 +1,13 @@
+use crate::character::Character;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
-use crate::{character::Character, packet::ServerMessageExt};
 use wow_world_messages::wrath::{ComplaintStatus, SMSG_FEATURE_SYSTEM_STATUS};
 
 pub async fn send_voice_chat_status(character: &Character) -> Result<()> {
-    SMSG_FEATURE_SYSTEM_STATUS {
+    ServerEvent::FeatureSystemStatus(SMSG_FEATURE_SYSTEM_STATUS {
         complaint_status: ComplaintStatus::EnabledWithAutoIgnore,
         voice_chat_enabled: false,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }

--- a/world_server/src/handlers/world_handler.rs
+++ b/world_server/src/handlers/world_handler.rs
@@ -1,6 +1,9 @@
+use std::net::SocketAddr;
+
+use crate::character::character_manager::CharacterManager;
 use crate::character::*;
 use crate::client_manager::ClientManager;
-use crate::packet::*;
+use crate::connection::events::ServerEvent;
 use crate::prelude::*;
 use wow_world_messages::wrath::Area;
 use wow_world_messages::wrath::Object;
@@ -13,16 +16,21 @@ use wow_world_messages::wrath::SMSG_TIME_SYNC_REQ;
 use wow_world_messages::wrath::SMSG_UPDATE_OBJECT;
 use wow_world_messages::wrath::SMSG_UPDATE_WORLD_STATE;
 
-pub async fn handle_cmsg_zoneupdate(client_manager: &ClientManager, client_id: u64, packet: &CMSG_ZONEUPDATE) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
-
-    let mut character = character_lock.write().await;
-    (*character).zone_update(packet.area).await
+pub async fn handle_cmsg_zoneupdate(
+    client_manager: &ClientManager,
+    character_manager: &mut CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_ZONEUPDATE,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character_mut(guid)?;
+    character.zone_update(packet.area).await?;
+    Ok(())
 }
 
 pub async fn send_initial_world_states(character: &Character) -> Result<()> {
-    SMSG_INIT_WORLD_STATES {
+    let msg = SMSG_INIT_WORLD_STATES {
         map: character.map,
         area: character.area,
         sub_area: Area::NorthshireValley, //TODO: implement sub-areas
@@ -39,42 +47,50 @@ pub async fn send_initial_world_states(character: &Character) -> Result<()> {
                 value: 1,
             },
         ],
-    }
-    .astd_send_to_character(character)
-    .await
+    };
+    ServerEvent::InitWorldStates(msg).send_to_character(character).await
 }
 
 #[allow(dead_code)]
 pub async fn send_world_state_update(character: &Character, world_state: WorldState) -> Result<()> {
-    SMSG_UPDATE_WORLD_STATE { state: world_state }.astd_send_to_character(character).await
+    ServerEvent::UpdateWorldState(SMSG_UPDATE_WORLD_STATE { state: world_state })
+        .send_to_character(character)
+        .await
 }
 
 pub async fn send_smsg_update_objects(character: &Character, objects: Vec<Object>) -> Result<()> {
-    SMSG_UPDATE_OBJECT { objects }.astd_send_to_character(character).await
+    ServerEvent::UpdateObject(SMSG_UPDATE_OBJECT { objects })
+        .send_to_character(character)
+        .await
 }
 
 pub async fn send_destroy_object(character: &Character, object_guid: Guid, is_death: bool) -> Result<()> {
-    SMSG_DESTROY_OBJECT {
+    ServerEvent::DestroyObject(SMSG_DESTROY_OBJECT {
         guid: object_guid,
         target_died: is_death,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
 pub async fn send_time_sync(character: &Character) -> Result<()> {
-    SMSG_TIME_SYNC_REQ {
+    ServerEvent::TimeSyncReq(SMSG_TIME_SYNC_REQ {
         time_sync: character.time_sync_counter,
-    }
-    .astd_send_to_character(character)
+    })
+    .send_to_character(character)
     .await
 }
 
-pub async fn handle_cmsg_time_sync_resp(client_manager: &ClientManager, client_id: u64, packet: &CMSG_TIME_SYNC_RESP) -> Result<()> {
-    let client = client_manager.get_authenticated_client(client_id).await?;
-    let character_lock = client.get_active_character().await?;
+pub async fn handle_cmsg_time_sync_resp(
+    client_manager: &ClientManager,
+    character_manager: &CharacterManager,
+    client_id: SocketAddr,
+    packet: &CMSG_TIME_SYNC_RESP,
+) -> Result<()> {
+    let client = client_manager.get_authenticated_client(client_id)?;
+    let guid = client.get_active_character();
+    let character = character_manager.get_character(guid)?;
 
-    let character = character_lock.read().await;
     if packet.time_sync != character.time_sync_counter {
         warn!(
             "Character {} has time sync issues. Reported: {}, expected {}, Could be cheating?",

--- a/world_server/src/packet.rs
+++ b/world_server/src/packet.rs
@@ -1,70 +1,18 @@
 use super::client::Client;
-use crate::{character::*, prelude::*, world::game_object::GameObject, world::World};
+use crate::{
+    character::{character_manager::CharacterManager, *},
+    connection::{events::ServerEvent, Connection},
+    prelude::*,
+    world::{game_object::GameObject, World},
+};
 use smol::prelude::*;
-use std::{borrow::Borrow, pin::Pin};
+use std::pin::Pin;
 use wow_world_messages::wrath::ServerMessage;
 
 pub trait ServerMessageExt: ServerMessage {
-    fn astd_send_to_all_in_range<'life0, 'life1, 'life2, 'async_trait>(
+    fn astd_send_to_connection<'life0, 'life1, 'async_trait>(
         &'life0 self,
-        character: impl Borrow<Character> + 'life1 + Send,
-        include_self: bool,
-        world: impl Borrow<World> + 'life2 + Send,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'async_trait>>
-    where
-        'life0: 'async_trait,
-        'life1: 'async_trait,
-        'life2: 'async_trait,
-        Self: Sync + 'async_trait,
-    {
-        Box::pin(async move {
-            let character = character.borrow();
-            let world = world.borrow();
-
-            if let Some(map) = world.get_instance_manager().try_get_map_for_character(character).await {
-                let in_range_guids = character.get_in_range_guids();
-                for guid in in_range_guids {
-                    let object_lock = map
-                        .try_get_object(guid)
-                        .await
-                        .ok_or_else(|| anyhow!("GUID is in range, but not a valid object"))?
-                        .upgrade()
-                        .ok_or_else(|| anyhow!("object was on the map, but is no longer valid to send packets to"))?;
-                    let read_obj = object_lock.read().await;
-                    if let Some(in_range_character) = read_obj.as_character() {
-                        self.astd_send_to_character(in_range_character).await?;
-                    }
-                }
-                if include_self {
-                    self.astd_send_to_character(character).await?;
-                }
-            } else {
-                warn!("Trying to send packet to all in range, but this character is not on a map");
-            }
-            Ok(())
-        })
-    }
-
-    fn astd_send_to_character<'life0, 'life1, 'async_trait>(
-        &'life0 self,
-        character: impl Borrow<Character> + 'life1 + Send,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'async_trait>>
-    where
-        'life0: 'async_trait,
-        'life1: 'async_trait,
-        Self: Sync + 'async_trait,
-    {
-        let client = character.borrow().client.upgrade().unwrap();
-        Box::pin(async move {
-            self.astd_write_encrypted_server(&mut *client.write_socket.lock().await, client.encryption.lock().await.as_mut().unwrap())
-                .await?;
-            Ok(())
-        })
-    }
-
-    fn astd_send_to_client<'life0, 'life1, 'async_trait>(
-        &'life0 self,
-        client: impl Borrow<Client> + 'life1 + Send,
+        connection: &'life1 mut Connection,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'async_trait>>
     where
         'life0: 'async_trait,
@@ -72,11 +20,44 @@ pub trait ServerMessageExt: ServerMessage {
         Self: Sync + 'async_trait,
     {
         Box::pin(async move {
-            let client: &Client = client.borrow();
-            self.astd_write_encrypted_server(&mut *client.write_socket.lock().await, client.encryption.lock().await.as_mut().unwrap())
+            self.astd_write_encrypted_server(&mut connection.stream, connection.encryption.as_mut().unwrap())
                 .await?;
             Ok(())
         })
     }
 }
 impl<T> ServerMessageExt for T where T: ServerMessage {}
+
+impl ServerEvent {
+    pub async fn send_to_all_in_range(
+        self,
+        character: &Character,
+        character_manager: &CharacterManager,
+        include_self: bool,
+        world: &World,
+    ) -> Result<()> {
+        if world.get_instance_manager().try_get_map_for_character(character).is_some() {
+            let in_range_guids = character.get_in_range_guids();
+            for guid in in_range_guids {
+                let in_range_character = character_manager.get_character(guid)?;
+                self.send_to_character(in_range_character).await?;
+            }
+            if include_self {
+                self.send_to_character(character).await?;
+            }
+        } else {
+            warn!("Trying to send packet to all in range, but this character is not on a map");
+        }
+        Ok(())
+    }
+
+    pub async fn send_to_character(&self, character: &Character) -> Result<()> {
+        character.connection_sender.send_async(self.clone()).await?;
+        Ok(())
+    }
+
+    pub async fn send_to_client(&self, client: &Client) -> Result<()> {
+        client.connection_sender.send_async(self.clone()).await?;
+        Ok(())
+    }
+}

--- a/world_server/src/packet_handler.rs
+++ b/world_server/src/packet_handler.rs
@@ -1,53 +1,41 @@
 use super::client_manager::ClientManager;
+use crate::character::character_manager::CharacterManager;
 use crate::client::ClientState;
 use crate::handlers::*;
 use crate::prelude::*;
 use crate::world::World;
-use std::sync::mpsc::Receiver;
-use std::sync::Arc;
+use std::net::SocketAddr;
 use wow_world_messages::wrath::opcodes::ClientOpcodeMessage;
 
 pub struct PacketToHandle {
-    pub client_id: u64,
+    pub client_id: SocketAddr,
     pub payload: Box<ClientOpcodeMessage>,
 }
 
-pub struct PacketHandler {
-    receive_channel: Receiver<PacketToHandle>,
-}
+pub struct PacketHandler {}
 
 impl PacketHandler {
-    pub fn new(packet_receiver_channel: Receiver<PacketToHandle>, _world: Arc<World>) -> Self {
-        Self {
-            receive_channel: packet_receiver_channel,
-        }
-    }
-
-    pub async fn handle_queue(&self, client_manager: Arc<ClientManager>, world: Arc<World>) -> Result<()> {
-        for packet in self.receive_channel.try_iter() {
-            self.handle_packet(&client_manager, &world, &packet).await.unwrap_or_else(|e| {
-                warn!("Error while handling packet {:?}: {}", packet.payload, e);
-            });
-        }
-
-        Ok(())
-    }
-
-    async fn handle_packet(&self, client_manager: &ClientManager, world: &World, packet: &PacketToHandle) -> Result<()> {
+    pub async fn handle_packet(
+        client_manager: &mut ClientManager,
+        character_manager: &mut CharacterManager,
+        world: &mut World,
+        packet: PacketToHandle,
+    ) -> Result<()> {
         if std::env::var("PRINT_INCOMING_PACKETS")?.parse::<usize>()? == 1usize {
             info!("Incoming: {:?}", packet.payload);
         }
         {
-            let client = client_manager.get_client(packet.client_id).await?;
+            let client = client_manager.get_client(packet.client_id)?;
             //Most likely this won't even be reached since the client manager can't find that
             //client
-            if client.data.read().await.client_state == ClientState::Disconnected {
+            if client.data.client_state == ClientState::Disconnected {
                 bail!("PacketHandler received a packet for a client that's already disconnected. Ignoring");
             }
         }
 
         match &*packet.payload {
-            ClientOpcodeMessage::CMSG_READY_FOR_ACCOUNT_DATA_TIMES => handle_csmg_ready_for_account_data_times(client_manager, packet).await,
+            ClientOpcodeMessage::CMSG_PLAYER_LOGOUT => handle_cmsg_player_logout(client_manager, character_manager, packet.client_id).await,
+            ClientOpcodeMessage::CMSG_READY_FOR_ACCOUNT_DATA_TIMES => handle_csmg_ready_for_account_data_times(client_manager, &packet).await,
             ClientOpcodeMessage::CMSG_UPDATE_ACCOUNT_DATA(data) => {
                 handle_csmg_update_account_data(client_manager, packet.client_id, world, data).await
             }
@@ -59,60 +47,104 @@ impl PacketHandler {
             ClientOpcodeMessage::CMSG_CHAR_ENUM => handle_cmsg_char_enum(client_manager, world, packet.client_id).await,
             ClientOpcodeMessage::CMSG_CHAR_CREATE(data) => handle_cmsg_char_create(client_manager, packet.client_id, world, data).await,
             ClientOpcodeMessage::CMSG_CHAR_DELETE(data) => handle_cmsg_char_delete(client_manager, packet.client_id, world, data).await,
-            ClientOpcodeMessage::CMSG_PLAYER_LOGIN(data) => handle_cmsg_player_login(client_manager, world, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_STANDSTATECHANGE(data) => handle_cmsg_standstate_change(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::MSG_MOVE_START_FORWARD(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_START_BACKWARD(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+            ClientOpcodeMessage::CMSG_PLAYER_LOGIN(data) => {
+                handle_cmsg_player_login(client_manager, character_manager, world, packet.client_id, data).await
             }
-            ClientOpcodeMessage::MSG_MOVE_STOP(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
+            ClientOpcodeMessage::CMSG_STANDSTATECHANGE(data) => {
+                handle_cmsg_standstate_change(client_manager, character_manager, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_START_FORWARD(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_START_BACKWARD(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_STOP(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
             ClientOpcodeMessage::MSG_MOVE_START_STRAFE_LEFT(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
             }
             ClientOpcodeMessage::MSG_MOVE_START_STRAFE_RIGHT(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
             }
-            ClientOpcodeMessage::MSG_MOVE_STOP_STRAFE(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_JUMP(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
+            ClientOpcodeMessage::MSG_MOVE_STOP_STRAFE(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_JUMP(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
             ClientOpcodeMessage::MSG_MOVE_START_TURN_LEFT(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
             }
             ClientOpcodeMessage::MSG_MOVE_START_TURN_RIGHT(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
             }
             ClientOpcodeMessage::MSG_MOVE_START_PITCH_UP(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
             }
             ClientOpcodeMessage::MSG_MOVE_START_PITCH_DOWN(data) => {
-                handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
             }
-            ClientOpcodeMessage::MSG_MOVE_STOP_PITCH(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_SET_RUN_MODE(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_SET_WALK_MODE(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_FALL_LAND(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_START_SWIM(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_STOP_SWIM(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_STOP_TURN(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_SET_FACING(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_HEARTBEAT(data) => handle_movement_generic(client_manager, packet.client_id, world, data.clone()).await,
-            ClientOpcodeMessage::MSG_MOVE_TELEPORT_ACK(data) => handle_msg_move_teleport_ack(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::MSG_MOVE_WORLDPORT_ACK => handle_msg_move_worldport_ack(client_manager, packet.client_id, world).await,
-            ClientOpcodeMessage::CMSG_WORLD_TELEPORT(data) => handle_msg_world_teleport(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_LOGOUT_REQUEST => handle_cmsg_logout_request(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_LOGOUT_CANCEL => handle_cmsg_logout_cancel(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_PLAYED_TIME(data) => handle_cmsg_played_time(client_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::MSG_MOVE_STOP_PITCH(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_SET_RUN_MODE(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_SET_WALK_MODE(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_FALL_LAND(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_START_SWIM(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_STOP_SWIM(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_STOP_TURN(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_SET_FACING(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_HEARTBEAT(data) => {
+                handle_movement_generic(client_manager, character_manager, packet.client_id, world, data.clone()).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_TELEPORT_ACK(data) => {
+                handle_msg_move_teleport_ack(client_manager, character_manager, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::MSG_MOVE_WORLDPORT_ACK => {
+                handle_msg_move_worldport_ack(client_manager, character_manager, packet.client_id, world).await
+            }
+            ClientOpcodeMessage::CMSG_WORLD_TELEPORT(data) => {
+                handle_msg_world_teleport(client_manager, character_manager, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::CMSG_LOGOUT_REQUEST => handle_cmsg_logout_request(client_manager, character_manager, packet.client_id).await,
+            ClientOpcodeMessage::CMSG_LOGOUT_CANCEL => handle_cmsg_logout_cancel(client_manager, character_manager, packet.client_id).await,
+            ClientOpcodeMessage::CMSG_PLAYED_TIME(data) => handle_cmsg_played_time(client_manager, character_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_QUERY_TIME => handle_cmsg_query_time(client_manager, packet.client_id).await,
             ClientOpcodeMessage::CMSG_WORLD_STATE_UI_TIMER_UPDATE => handle_cmsg_world_state_ui_timer_update(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_TIME_SYNC_RESP(data) => handle_cmsg_time_sync_resp(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_ZONEUPDATE(data) => handle_cmsg_zoneupdate(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_AREATRIGGER(data) => handle_cmsg_areatrigger(client_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::CMSG_TIME_SYNC_RESP(data) => {
+                handle_cmsg_time_sync_resp(client_manager, character_manager, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::CMSG_ZONEUPDATE(data) => handle_cmsg_zoneupdate(client_manager, character_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::CMSG_AREATRIGGER(data) => handle_cmsg_areatrigger(client_manager, character_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_FORCE_MOVE_ROOT_ACK(_) => Ok(()),
             ClientOpcodeMessage::CMSG_FORCE_MOVE_UNROOT_ACK(_) => Ok(()),
             ClientOpcodeMessage::CMSG_SET_ACTIVE_MOVER(data) => handle_cmsg_set_active_mover(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_NAME_QUERY(data) => handle_cmsg_name_query(client_manager, packet.client_id, world, data).await,
-            ClientOpcodeMessage::CMSG_TUTORIAL_FLAG(data) => handle_cmsg_tutorial_flag(client_manager, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_TUTORIAL_RESET => handle_cmsg_tutorial_reset(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_SET_SELECTION(data) => handle_csmg_set_selection(client_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::CMSG_NAME_QUERY(data) => {
+                handle_cmsg_name_query(client_manager, character_manager, packet.client_id, world, data).await
+            }
+            ClientOpcodeMessage::CMSG_TUTORIAL_FLAG(data) => {
+                handle_cmsg_tutorial_flag(client_manager, character_manager, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::CMSG_TUTORIAL_RESET => handle_cmsg_tutorial_reset(client_manager, character_manager, packet.client_id).await,
+            ClientOpcodeMessage::CMSG_SET_SELECTION(data) => {
+                handle_cmsg_set_selection(client_manager, character_manager, packet.client_id, data).await
+            }
             ClientOpcodeMessage::CMSG_JOIN_CHANNEL(data) => handle_cmsg_join_channel(client_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_SET_ACTIVE_VOICE_CHANNEL(_) => {
                 //Voice chat is explicitly not implemented, discard message to silence warning spam
@@ -125,18 +157,30 @@ impl PacketHandler {
             ClientOpcodeMessage::CMSG_GMTICKET_GETTICKET => handle_cmsg_gmticket_getticket(client_manager, packet.client_id).await,
             ClientOpcodeMessage::CMSG_GMTICKET_CREATE(data) => handle_cmsg_gmticket_create(client_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_GMTICKET_SYSTEMSTATUS => handle_cmsg_gmticket_system_status(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_NEXT_CINEMATIC_CAMERA => handle_csmg_next_cinematic_camera(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_COMPLETE_CINEMATIC => handle_csmg_complete_cinematic(client_manager, packet.client_id).await,
+            ClientOpcodeMessage::CMSG_NEXT_CINEMATIC_CAMERA => {
+                handle_csmg_next_cinematic_camera(client_manager, character_manager, packet.client_id).await
+            }
+            ClientOpcodeMessage::CMSG_COMPLETE_CINEMATIC => handle_csmg_complete_cinematic(client_manager, character_manager, packet.client_id).await,
             ClientOpcodeMessage::CMSG_REQUEST_RAID_INFO => handle_cmsg_request_raid_info(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_CONTACT_LIST(data) => handle_cmsg_contact_list(client_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::CMSG_CONTACT_LIST(data) => handle_cmsg_contact_list(client_manager, character_manager, packet.client_id, data).await,
             ClientOpcodeMessage::CMSG_CALENDAR_GET_NUM_PENDING => handle_cmsg_calendar_get_num_pending(client_manager, packet.client_id).await,
-            ClientOpcodeMessage::CMSG_SET_ACTIONBAR_TOGGLES(data) => handle_csmg_set_actionbar_toggles(client_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::CMSG_SET_ACTIONBAR_TOGGLES(data) => {
+                handle_csmg_set_actionbar_toggles(client_manager, character_manager, packet.client_id, data).await
+            }
             ClientOpcodeMessage::CMSG_ITEM_QUERY_SINGLE(data) => handle_cmsg_item_query_single(client_manager, packet.client_id, world, data).await,
             ClientOpcodeMessage::CMSG_ITEM_NAME_QUERY(data) => handle_cmsg_item_name_query(client_manager, packet.client_id, world, data).await,
-            ClientOpcodeMessage::CMSG_SWAP_INV_ITEM(data) => handle_cmsg_swap_inv_item(client_manager, world, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_AUTOEQUIP_ITEM(data) => handle_cmsg_autoequip_item(client_manager, world, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_MESSAGECHAT(data) => handle_cmsg_messagechat(client_manager, world, packet.client_id, data).await,
-            ClientOpcodeMessage::CMSG_SET_ACTION_BUTTON(data) => handle_cmsg_set_action_button(client_manager, packet.client_id, data).await,
+            ClientOpcodeMessage::CMSG_SWAP_INV_ITEM(data) => {
+                handle_cmsg_swap_inv_item(client_manager, character_manager, world, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::CMSG_AUTOEQUIP_ITEM(data) => {
+                handle_cmsg_autoequip_item(client_manager, character_manager, world, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::CMSG_MESSAGECHAT(data) => {
+                handle_cmsg_messagechat(client_manager, character_manager, world, packet.client_id, data).await
+            }
+            ClientOpcodeMessage::CMSG_SET_ACTION_BUTTON(data) => {
+                handle_cmsg_set_action_button(client_manager, character_manager, packet.client_id, data).await
+            }
             _ => bail!("Unhandled opcode"),
         }
     }

--- a/world_server/src/world/game_object.rs
+++ b/world_server/src/world/game_object.rs
@@ -10,7 +10,6 @@ use crate::character::Character;
 use crate::data::PositionAndOrientation;
 use crate::prelude::*;
 
-#[async_trait::async_trait]
 pub trait GameObject: Send + Sync {
     //Gets position of object. Some objects may not have position (Item, Container) = None
     fn get_position(&self) -> Option<PositionAndOrientation>;
@@ -19,7 +18,9 @@ pub trait GameObject: Send + Sync {
     fn clear_update_mask_header(&mut self);
     fn is_in_range(&self, guid: Guid) -> bool;
     fn add_in_range_object(&mut self, guid: Guid, object: Weak<RwLock<dyn GameObject>>) -> Result<()>;
+    fn add_in_range_character(&mut self, guid: Guid) -> Result<()>;
     fn get_in_range_guids(&self) -> Vec<Guid>;
+    fn get_in_range_characters(&self) -> &[Guid];
     fn remove_in_range_object(&mut self, guid: Guid) -> Result<()>;
     fn clear_in_range_objects(&mut self);
     fn get_recently_removed_range_guids(&self) -> &[Guid];
@@ -31,5 +32,5 @@ pub trait GameObject: Send + Sync {
 
     fn get_guid(&self) -> Guid;
     fn get_type(&self) -> ObjectType;
-    async fn on_pushed_to_map(&mut self, map_manager: &MapManager) -> Result<()>;
+    fn on_pushed_to_map(&mut self, map_manager: &MapManager) -> Result<()>;
 }

--- a/world_server/src/world/instance_manager.rs
+++ b/world_server/src/world/instance_manager.rs
@@ -1,9 +1,8 @@
+use crate::character::character_manager::CharacterManager;
 use crate::character::Character;
 use crate::client::Client;
 use crate::prelude::*;
-use smol::lock::{RwLock, RwLockUpgradableReadGuard};
 use std::collections::HashMap;
-use std::sync::Arc;
 use wow_world_messages::wrath::Map;
 
 use super::map_manager::MapManager;
@@ -16,50 +15,49 @@ pub type MapID = u32;
 pub struct InstanceManager {
     //Multiple instances are things like raids and dungeons which can spawn many times for
     //different groups
-    multiple_instances: RwLock<HashMap<InstanceID, Arc<MapManager>>>,
-    world_maps: RwLock<HashMap<MapID, Arc<MapManager>>>,
+    multiple_instances: HashMap<InstanceID, MapManager>,
+    world_maps: HashMap<MapID, MapManager>,
 }
 
 impl InstanceManager {
     pub fn new() -> Self {
         Self {
-            multiple_instances: RwLock::new(HashMap::default()),
-            world_maps: RwLock::new(HashMap::default()),
+            multiple_instances: HashMap::default(),
+            world_maps: HashMap::default(),
         }
     }
 
-    pub async fn tick(&self, delta_time: f32) -> Result<()> {
-        self.tick_maps::<MapID>(&self.world_maps, delta_time).await?;
-        self.tick_maps::<InstanceID>(&self.multiple_instances, delta_time).await?;
-        self.cleanup_maps::<MapID>(&self.world_maps).await?;
-        self.cleanup_maps::<InstanceID>(&self.multiple_instances).await?;
+    pub async fn tick(&mut self, character_manager: &mut CharacterManager, delta_time: f32) -> Result<()> {
+        Self::tick_maps::<MapID>(&mut self.world_maps, character_manager, delta_time).await?;
+        Self::tick_maps::<InstanceID>(&mut self.multiple_instances, character_manager, delta_time).await?;
+        Self::cleanup_maps::<MapID>(&mut self.world_maps).await?;
+        Self::cleanup_maps::<InstanceID>(&mut self.multiple_instances).await?;
 
         Ok(())
     }
 
-    async fn tick_maps<T: PartialEq + Clone>(&self, list: &RwLock<HashMap<T, Arc<MapManager>>>, delta_time: f32) -> Result<()> {
-        let maps = list.read().await;
-        for map in maps.values() {
-            map.tick(delta_time).await?;
+    async fn tick_maps<T: PartialEq + Clone>(
+        maps: &mut HashMap<T, MapManager>,
+        character_manager: &mut CharacterManager,
+        delta_time: f32,
+    ) -> Result<()> {
+        for map in maps.values_mut() {
+            map.tick(delta_time, character_manager).await?;
         }
         Ok(())
     }
 
-    async fn cleanup_maps<T: PartialEq + Clone>(&self, list: &RwLock<HashMap<T, Arc<MapManager>>>) -> Result<()> {
+    async fn cleanup_maps<T: PartialEq + Clone>(maps: &mut HashMap<T, MapManager>) -> Result<()> {
         let mut to_cleanup = Vec::new();
 
-        let maps = list.upgradable_read().await;
-        {
-            for (id, map) in maps.iter() {
-                if map.should_shutdown().await {
-                    map.shutdown().await?;
-                    to_cleanup.push(id.clone());
-                }
+        for (id, map) in maps.iter() {
+            if map.should_shutdown().await {
+                map.shutdown().await?;
+                to_cleanup.push(id.clone());
             }
         }
 
         if !to_cleanup.is_empty() {
-            let mut maps = RwLockUpgradableReadGuard::upgrade(maps).await;
             maps.retain(|k, _| !to_cleanup.contains(k));
         }
 
@@ -71,15 +69,9 @@ impl InstanceManager {
         false
     }
 
-    pub async fn get_or_create_map(&self, object: &impl GameObject, map: Map) -> Result<Arc<MapManager>> {
+    pub async fn get_or_create_map(&mut self, object: &impl GameObject, map: Map) -> Result<&mut MapManager> {
         let map = if !self.is_instance(map) {
-            Ok(self
-                .world_maps
-                .write()
-                .await
-                .entry(map.as_int())
-                .or_insert_with(|| Arc::new(MapManager::new(map.as_int())))
-                .clone())
+            Ok(self.world_maps.entry(map.as_int()).or_insert_with(|| MapManager::new(map.as_int())))
         } else if let Some(character) = object.as_character() {
             Ok(self.get_or_create_map_for_instance(map, character.instance_id).await)
         } else {
@@ -89,33 +81,36 @@ impl InstanceManager {
         map
     }
 
-    pub async fn try_get_map_for_instance(&self, instance_id: InstanceID) -> Option<Arc<MapManager>> {
-        self.multiple_instances.read().await.get(&instance_id).cloned()
+    pub async fn try_get_map_for_instance(&self, instance_id: InstanceID) -> Option<&MapManager> {
+        self.multiple_instances.get(&instance_id)
     }
 
-    pub async fn try_get_map_for_character(&self, character: &Character) -> Option<Arc<MapManager>> {
+    pub fn try_get_map_for_character(&self, character: &Character) -> Option<&MapManager> {
         if !self.is_instance(character.map) {
-            self.world_maps.read().await.get(&character.map.as_int()).cloned()
+            self.world_maps.get(&character.map.as_int())
         } else {
-            self.multiple_instances.read().await.get(&character.instance_id).cloned()
+            self.multiple_instances.get(&character.instance_id)
         }
     }
 
-    async fn get_or_create_map_for_instance(&self, map: Map, instance_id: InstanceID) -> Arc<MapManager> {
-        self.multiple_instances
-            .write()
-            .await
-            .entry(instance_id)
-            .or_insert(Arc::new(MapManager::new(map.as_int())))
-            .clone()
+    pub fn try_get_map_for_character_mut(&mut self, character: &Character) -> Option<&mut MapManager> {
+        if !self.is_instance(character.map) {
+            self.world_maps.get_mut(&character.map.as_int())
+        } else {
+            self.multiple_instances.get_mut(&character.instance_id)
+        }
     }
 
-    pub async fn handle_client_disconnected(&self, client: &Client) -> Result<()> {
-        if let Some(character_lock) = &client.data.read().await.active_character {
-            let active_character = character_lock.read().await;
-            let map = self.try_get_map_for_character(&active_character).await;
+    async fn get_or_create_map_for_instance(&mut self, map: Map, instance_id: InstanceID) -> &mut MapManager {
+        self.multiple_instances.entry(instance_id).or_insert(MapManager::new(map.as_int()))
+    }
+
+    pub async fn handle_client_disconnected(&mut self, client: &Client, character_manager: &CharacterManager) -> Result<()> {
+        if let Some(guid) = client.data.active_character {
+            let character = character_manager.get_character(guid)?;
+            let map = self.try_get_map_for_character_mut(character);
             if let Some(map) = map {
-                map.remove_object_by_guid(active_character.get_guid()).await;
+                map.remove_object_by_guid(guid);
             }
         }
 

--- a/world_server/src/world/mod.rs
+++ b/world_server/src/world/mod.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{character::character_manager::CharacterManager, prelude::*};
 use instance_manager::InstanceManager;
 use std::sync::Arc;
 use wrath_realm_db::RealmDatabase;
@@ -17,28 +17,32 @@ pub mod prelude {
 }
 
 pub struct World {
-    instance_manager: Arc<InstanceManager>,
+    instance_manager: InstanceManager,
     realm_db: Arc<RealmDatabase>,
 }
 
 impl World {
     pub fn new(realm_db: Arc<RealmDatabase>) -> Self {
         Self {
-            instance_manager: Arc::new(InstanceManager::new()),
+            instance_manager: InstanceManager::new(),
             realm_db,
         }
     }
 
-    pub fn get_instance_manager(&self) -> Arc<InstanceManager> {
-        self.instance_manager.clone()
+    pub fn get_instance_manager(&self) -> &InstanceManager {
+        &self.instance_manager
+    }
+
+    pub fn get_instance_manager_mut(&mut self) -> &mut InstanceManager {
+        &mut self.instance_manager
     }
 
     pub fn get_realm_database(&self) -> Arc<RealmDatabase> {
         self.realm_db.clone()
     }
 
-    pub async fn tick(&self, delta_time: f32) -> Result<()> {
-        self.instance_manager.tick(delta_time).await?;
+    pub async fn tick(&mut self, character_manager: &mut CharacterManager, delta_time: f32) -> Result<()> {
+        self.instance_manager.tick(character_manager, delta_time).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Key changes:

- Added connection/ (per-connection task) with `Connection` + `events` enums for ClientEvent/ServerEvent.
- Added `connections.rs` accept loop resolving bind endpoint from auth DB (per realm via REALM_ID).
- Introduced `ClientManager` owning a `HashMap<SocketAddr, Client>` and a flume channel (no Arc<Mutex> around client sets).
- Introduced `CharacterManager` (central character storage & operations) distinct from connection management.
- Converted packet handling to push `ClientEvent::Message` through flume instead of locking shared state.
- Reworked movement / handlers to take `&mut CharacterManager` / `&mut World` directly (borrows instead of runtime locks).
- Moved authentication handshake into `Connection::update` and then announce via `ClientEvent::Connected` with a per-connection `ServerEvent` sender.
- Centralized outbound packet sending through a dedicated `ServerEvent` channel, decoupling IO from gameplay logic.
- Removed prior reliance on synchronized (Mutex/RwLock) patterns by using single-threaded async executor ownership + message passing.
- Consolidated common crates (anyhow, tracing, smol, flume, wow_login_messages, wow_world_messages) into `[workspace.dependencies]` for consistency and simpler version management.

Why:

- Eliminates contention and potential deadlocks from coarse-grained locks by enforcing single-owner mutable access in the main tick loop.
- Channels provide backpressure and clear data flow boundaries (network -> manager -> world) improving reasoning and testability.
- Separation of concerns (`Connection` vs `ClientManager` vs `CharacterManager`) prevents incidental shared mutable state and reduces need for synchronization primitives.
- Deterministic ordering in the tick loop simplifies temporal logic (movement, logout, teleport) without lock ordering concerns.

Follow up ideas:
- Backpressure metrics & queue length monitoring.
- Instrument latency per event type.
- Potential sharding of ClientManager by realm instance or map.