### PR TITLE
Persist inventory and fix greyed equipped items

### DIFF
--- a/databases/wrath-realm-db/.sqlx/query-5cd7b2f40b1adf7549e4821786723b99c23e70b149d9e67efac42e6269f525fd.json
+++ b/databases/wrath-realm-db/.sqlx/query-5cd7b2f40b1adf7549e4821786723b99c23e70b149d9e67efac42e6269f525fd.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM character_equipment WHERE character_id = ? AND slot_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "5cd7b2f40b1adf7549e4821786723b99c23e70b149d9e67efac42e6269f525fd"
+}

--- a/databases/wrath-realm-db/src/item_instance.rs
+++ b/databases/wrath-realm-db/src/item_instance.rs
@@ -27,4 +27,15 @@ impl super::RealmDatabase {
         .await?;
         Ok(())
     }
+
+    pub async fn delete_character_item(&self, character_id: u32, slot_id: u8) -> Result<()> {
+        sqlx::query!(
+            "DELETE FROM character_equipment WHERE character_id = ? AND slot_id = ?",
+            character_id,
+            slot_id
+        )
+        .execute(&self.connection_pool)
+        .await?;
+        Ok(())
+    }
 }

--- a/world_server/src/character/character_inventory.rs
+++ b/world_server/src/character/character_inventory.rs
@@ -1,5 +1,6 @@
 use crate::connection::events::ServerEvent;
 use crate::item::item_container::ItemContainer;
+use crate::world::prelude::GameObject;
 use crate::{
     item::Item,
     prelude::*,
@@ -157,114 +158,241 @@ impl ItemContainer<BagSlot> for BagInventory {
 }
 
 impl crate::character::Character {
+    async fn send_item_update(item: &Item, connection_sender: &flume::Sender<ServerEvent>) {
+        let object = Object {
+            update_type: Object_UpdateType::CreateObject {
+                guid3: item.update_state.object_guid().unwrap(),
+                mask2: UpdateMask::Item(item.update_state.clone()),
+                movement2: MovementBlock {
+                    update_flag: MovementBlock_UpdateFlag::empty(),
+                },
+                object_type: ObjectType::Item,
+            },
+        };
+        let msg = SMSG_UPDATE_OBJECT { objects: vec![object] };
+        let _ = connection_sender.send_async(ServerEvent::UpdateObject(msg)).await;
+    }
+
     //This function is meant to be used both with inventory and equipment or bags
     //It sets the item in the slot, and returns the old item if there was one
     //Doesn't check if the item is compatible with the slot
     //Slot is u16 because lower 8 bits contain slot data and upper 8 bits contain bag data
-    pub fn set_item(&mut self, item: Option<Item>, item_position: (u8, u8)) -> Result<Option<Item>> {
-        match item_position {
-            (slot, INVENTORY_SLOT_BAG_0) => {
-                if let Ok(equipment_slot) = EquipmentSlot::try_from(slot) {
-                    let previous_item = self.equipped_items.take_item(equipment_slot);
-                    if let Some(item) = item {
-                        if slot <= inventory::EQUIPMENT_SLOTS_END {
-                            //TODO: add display enchants
-                            self.gameplay_data.set_player_visible_item(
-                                VisibleItem::new(item.update_state.object_entry().unwrap() as u32, [0u16; 2]),
-                                VisibleItemIndex::try_from(slot).unwrap(),
-                            );
-                        }
-                        self.gameplay_data
-                            .set_player_field_inv(ItemSlot::try_from(slot).unwrap(), item.update_state.object_guid().unwrap());
-                        self.equipped_items.try_insert_item(item)?;
-                    } else {
-                        if slot <= inventory::EQUIPMENT_SLOTS_END {
-                            self.gameplay_data
-                                .set_player_visible_item(VisibleItem::new(0u32, [0u16; 2]), VisibleItemIndex::try_from(slot).unwrap());
-                        }
-                        self.gameplay_data.set_player_field_inv(ItemSlot::try_from(slot).unwrap(), Guid::zero());
-                    }
-                    Ok(previous_item)
-                } else if let Ok(bag_slot) = inventory::BagSlot::try_from(slot) {
-                    //TODO: add persistent bag for character and complete the implementation here
-                    let previous_item = self.bag_items.take_item(bag_slot);
-                    if let Some(item) = item {
-                        self.gameplay_data
-                            .set_player_field_inv(ItemSlot::try_from(slot).unwrap(), item.update_state.object_guid().unwrap());
-                        self.bag_items[bag_slot] = Some(item);
-                    } else {
-                        self.gameplay_data.set_player_field_inv(ItemSlot::try_from(slot).unwrap(), Guid::zero());
-                        self.bag_items[bag_slot] = None;
-                    }
-                    Ok(previous_item)
-                } else {
-                    todo!("Non-equipment inventory not implemented yet")
-                }
-            }
-            (_, _) => todo!("Bags not implemented yet"),
+    pub async fn set_item(
+        &mut self,
+        item: Option<Item>,
+        item_position: (u8, u8),
+        realm_db: Option<&wrath_realm_db::RealmDatabase>,
+        connection_sender: Option<&flume::Sender<ServerEvent>>,
+    ) -> Result<Option<Item>> {
+        let (slot, bag) = item_position;
+
+        if bag != INVENTORY_SLOT_BAG_0 {
+            todo!("Bags not implemented yet");
+        }
+
+        let character_id = self.get_guid().guid() as u32;
+
+        if let Ok(equipment_slot) = EquipmentSlot::try_from(slot) {
+            self.set_equipment_item(item, slot, equipment_slot, character_id, realm_db, connection_sender)
+                .await
+        } else if let Ok(bag_slot) = inventory::BagSlot::try_from(slot) {
+            self.set_bag_item(item, slot, bag_slot, character_id, realm_db, connection_sender).await
+        } else {
+            todo!("Non-equipment inventory not implemented yet")
         }
     }
 
-    //Attempt to auto-equip (right click equipable item from inventory) an item.
-    //Returns the item that was prevously in that equipment slot, or None if the slot was empty.
-    pub fn auto_equip_item_from_bag(&mut self, item_position: (u8, u8)) -> Result<Option<Item>> {
-        match item_position {
-            (slot, INVENTORY_SLOT_BAG_0) => {
-                if let Ok(bag_slot) = inventory::BagSlot::try_from(slot) {
-                    let item_to_equip = self.bag_items.take_item(bag_slot);
-                    if let Some(item) = item_to_equip {
-                        let item_inventory_type = item.get_inventory_type();
-                        let possible_equip_slots = get_compatible_equipment_slots_for_inventory_type(&item_inventory_type);
+    /// Rebuild the item's `UpdateItem` with a new object GUID.
+    ///
+    /// The client associates item objects with inventory/equipment cells using the
+    /// object's GUID. We encode the GUID as a 64-bit value where:
+    /// - high 32 bits = character id
+    /// - low  32 bits = slot id (bag/equipment slot)
+    ///
+    /// Example (binary):
+    /// - character_id = 10 => high 32 bits = 00000000 00000000 00000000 00001010
+    /// - slot         = 3  => low  32 bits = 00000000 00000000 00000000 00000011
+    /// - GUID (binary) = <high 32 bits> <low 32 bits>
+    ///   00000000 00000000 00000000 00001010 00000000 00000000 00000000 00000011
+    ///
+    /// Constructed in code as: ((character_id as u64) << 32) | (slot as u64).
+    /// Rebuilding preserves other fields (entry, owner, stack, durability) because
+    /// `UpdateItem` does not expose setters for those fields.
+    fn set_item_guid(item: &mut Item, guid: Guid) {
+        let entry = item.update_state.object_entry().unwrap_or(0);
+        let scale = item.update_state.object_scale_x().unwrap_or(1.0);
+        let owner = item.update_state.item_owner().unwrap_or(Guid::zero());
+        let contained = item.update_state.item_contained().unwrap_or(Guid::zero());
+        let stack = item.update_state.item_stack_count().unwrap_or(1);
+        let durability = item.update_state.item_durability().unwrap_or(100);
+        let maxdur = item.update_state.item_maxdurability().unwrap_or(100);
 
-                        let mut best_slot_candidate = None;
-                        for possible_equip_slot in possible_equip_slots {
-                            if best_slot_candidate.is_none() {
-                                best_slot_candidate = Some(possible_equip_slot);
-                            }
-                            if self.equipped_items.get_item(*possible_equip_slot).is_none() {
-                                //If we find a slot that has no other items inside, we have landed
-                                //on a winner automatically. We can stop.
-                                best_slot_candidate = Some(possible_equip_slot);
-                                break;
-                            }
-                        }
-
-                        if let Some(picked_slot) = best_slot_candidate {
-                            //Replace the item
-                            let previous_item_in_slot = self.set_item(Some(item), (*picked_slot as u8, INVENTORY_SLOT_BAG_0))?;
-                            return Ok(previous_item_in_slot);
-                        } else {
-                            warn!("No slot found to auto-equip this item into!");
-                        }
-                    } else {
-                        warn!("Attempting to auto-equip a non-existant item");
-                    }
-                }
-            }
-            (_, _) => todo!("Bags not implemented yet"),
-        }
-        bail!("Item not from bag 1");
+        item.update_state = UpdateItemBuilder::new()
+            .set_object_guid(guid)
+            .set_object_entry(entry)
+            .set_object_scale_x(scale)
+            .set_item_owner(owner)
+            .set_item_contained(contained)
+            .set_item_stack_count(stack)
+            .set_item_durability(durability)
+            .set_item_maxdurability(maxdur)
+            .finalize();
     }
 
-    #[allow(dead_code)]
-    fn has_item_in_slot(&self, item_position: (u8, u8)) -> bool {
-        match item_position {
-            (slot, INVENTORY_SLOT_BAG_0) => {
-                if let Ok(equipment_slot) = EquipmentSlot::try_from(slot) {
-                    self.equipped_items.get_item(equipment_slot).is_some()
-                } else if let Ok(bag_slot) = inventory::BagSlot::try_from(slot) {
-                    self.bag_items[bag_slot].is_some()
-                } else {
-                    todo!("Non-equipment inventory not implemented yet")
+    async fn set_equipment_item(
+        &mut self,
+        item: Option<Item>,
+        slot: u8,
+        equipment_slot: EquipmentSlot,
+        character_id: u32,
+        realm_db: Option<&wrath_realm_db::RealmDatabase>,
+        connection_sender: Option<&flume::Sender<ServerEvent>>,
+    ) -> Result<Option<Item>> {
+        let previous_item = self.equipped_items.take_item(equipment_slot);
+
+        match item {
+            Some(mut item) => {
+                let item_id = item.update_state.object_entry().unwrap() as u32;
+
+                let new_guid = ((character_id as u64) << 32 | slot as u64).into();
+                Self::set_item_guid(&mut item, new_guid);
+
+                self.update_visible_item(slot, &item);
+                self.update_inventory_field(slot, new_guid);
+
+                if let Some(sender) = connection_sender {
+                    Self::send_item_update(&item, sender).await;
+                }
+
+                self.equipped_items.try_insert_item(item)?;
+
+                if let Some(db) = realm_db {
+                    let _ = db.delete_character_item(character_id, slot).await;
+                    let _ = db.insert_character_item(character_id, slot, item_id).await;
                 }
             }
-            (_, _) => todo!("Bags not implemented yet"),
+            None => {
+                self.clear_visible_item(slot);
+                self.update_inventory_field(slot, Guid::zero());
+                if let Some(db) = realm_db {
+                    let _ = db.delete_character_item(character_id, slot).await;
+                }
+            }
         }
+
+        Ok(previous_item)
+    }
+
+    async fn set_bag_item(
+        &mut self,
+        item: Option<Item>,
+        slot: u8,
+        bag_slot: BagSlot,
+        character_id: u32,
+        realm_db: Option<&wrath_realm_db::RealmDatabase>,
+        connection_sender: Option<&flume::Sender<ServerEvent>>,
+    ) -> Result<Option<Item>> {
+        let previous_item = self.bag_items.take_item(bag_slot);
+
+        if let Some(mut item) = item {
+            let item_id = item.update_state.object_entry().unwrap() as u32;
+
+            let new_guid = ((character_id as u64) << 32 | slot as u64).into();
+            Self::set_item_guid(&mut item, new_guid);
+
+            if let Some(sender) = connection_sender {
+                Self::send_item_update(&item, sender).await;
+            }
+
+            if let Some(db) = realm_db {
+                let _ = db.delete_character_item(character_id, slot).await;
+                let _ = db.insert_character_item(character_id, slot, item_id).await;
+            }
+
+            let guid = new_guid;
+            self.update_inventory_field(slot, guid);
+            self.bag_items[bag_slot] = Some(item);
+        } else {
+            if let Some(db) = realm_db {
+                let _ = db.delete_character_item(character_id, slot).await;
+            }
+            self.update_inventory_field(slot, Guid::zero());
+            self.bag_items[bag_slot] = None;
+        }
+
+        Ok(previous_item)
+    }
+
+    fn update_visible_item(&mut self, slot: u8, item: &Item) {
+        if slot <= inventory::EQUIPMENT_SLOTS_END {
+            //TODO: add display enchants
+            let visible_item = VisibleItem::new(item.update_state.object_entry().unwrap() as u32, [0u16; 2]);
+            self.gameplay_data
+                .set_player_visible_item(visible_item, VisibleItemIndex::try_from(slot).unwrap());
+        }
+    }
+
+    fn clear_visible_item(&mut self, slot: u8) {
+        if slot <= inventory::EQUIPMENT_SLOTS_END {
+            self.gameplay_data
+                .set_player_visible_item(VisibleItem::new(0u32, [0u16; 2]), VisibleItemIndex::try_from(slot).unwrap());
+        }
+    }
+
+    fn update_inventory_field(&mut self, slot: u8, guid: Guid) {
+        self.gameplay_data.set_player_field_inv(ItemSlot::try_from(slot).unwrap(), guid);
+    }
+
+    /// Equips an item from inventory to the first compatible equipment slot.
+    /// Returns the previously equipped item from that slot, if any.
+    pub async fn auto_equip_item_from_bag(
+        &mut self,
+        item_position: (u8, u8),
+        realm_db: Option<&wrath_realm_db::RealmDatabase>,
+        connection_sender: Option<&flume::Sender<ServerEvent>>,
+    ) -> Result<Option<Item>> {
+        let (slot, bag) = item_position;
+
+        if bag != INVENTORY_SLOT_BAG_0 {
+            todo!("Bags not implemented yet");
+        }
+
+        let bag_slot = inventory::BagSlot::try_from(slot)?;
+        let Some(item) = self.bag_items.take_item(bag_slot) else {
+            bail!("No item in that slot");
+        };
+
+        // Remove previous DB entry for that bag slot since item is being moved
+        let character_id = self.get_guid().guid() as u32;
+        if let Some(db) = realm_db {
+            let _ = db.delete_character_item(character_id, bag_slot as u8).await;
+        }
+
+        let item_inventory = item.get_inventory_type();
+
+        let possible_slots = get_compatible_equipment_slots_for_inventory_type(&item_inventory);
+
+        // Find first empty slot, or fall back to the first available slot
+        let Some(&target_slot) = possible_slots
+            .iter()
+            .find(|&&slot| self.equipped_items.get_item(slot).is_none())
+            .or_else(|| possible_slots.first())
+        else {
+            bail!("No compatible equipment slot");
+        };
+
+        self.set_item(Some(item), (target_slot as u8, INVENTORY_SLOT_BAG_0), realm_db, connection_sender)
+            .await
     }
 
     // Try to add item to first available backpack slot (BagSlot::Item1-Item16)
-    pub async fn try_add_item_to_backpack(&mut self, item_id: u32, character_id: u32, connection_sender: &flume::Sender<ServerEvent>) -> Option<u8> {
-        let mut added_slot: Option<u8> = None;
+    pub async fn try_add_item_to_backpack(
+        &mut self,
+        item_id: u32,
+        character_id: u32,
+        connection_sender: &flume::Sender<ServerEvent>,
+        realm_db: Option<&wrath_realm_db::RealmDatabase>,
+    ) -> Option<u8> {
         for slot_id in (BagSlot::Item1 as u8)..=(BagSlot::Item16 as u8) {
             let bag_slot = BagSlot::try_from(slot_id).unwrap();
             if self.bag_items[bag_slot].is_some() {
@@ -284,34 +412,15 @@ impl crate::character::Character {
                     .finalize(),
             };
 
-            if self.set_item(Some(item), (slot_id, INVENTORY_SLOT_BAG_0)).is_ok() {
-                added_slot = Some(slot_id);
-                break;
+            if self
+                .set_item(Some(item), (slot_id, INVENTORY_SLOT_BAG_0), realm_db, Some(connection_sender))
+                .await
+                .is_ok()
+            {
+                return Some(slot_id);
             }
         }
 
-        // If we added the item, inform the client about it
-        let slot_id = added_slot?;
-        let bag_slot = BagSlot::try_from(slot_id).unwrap();
-        let added_item = self.bag_items[bag_slot].as_ref().unwrap();
-
-        let object = Object {
-            update_type: Object_UpdateType::CreateObject {
-                guid3: added_item.update_state.object_guid().unwrap(),
-                mask2: UpdateMask::Item(added_item.update_state.clone()),
-                movement2: MovementBlock {
-                    update_flag: MovementBlock_UpdateFlag::empty(),
-                },
-                object_type: ObjectType::Item,
-            },
-        };
-
-        let msg = SMSG_UPDATE_OBJECT { objects: vec![object] };
-        let event = ServerEvent::UpdateObject(msg);
-        if connection_sender.send_async(event).await.is_err() {
-            return None;
-        }
-
-        Some(slot_id)
+        None
     }
 }

--- a/world_server/src/character/character_inventory.rs
+++ b/world_server/src/character/character_inventory.rs
@@ -264,7 +264,7 @@ impl crate::character::Character {
                     Self::send_item_update(&item, sender).await;
                 }
 
-                self.equipped_items.try_insert_item(item)?;
+                self.equipped_items.items.insert(equipment_slot, item);
 
                 if let Some(db) = realm_db {
                     let _ = db.delete_character_item(character_id, slot).await;

--- a/world_server/src/handlers/gm_handler.rs
+++ b/world_server/src/handlers/gm_handler.rs
@@ -130,11 +130,12 @@ pub async fn handle_additem_command(
     let character = character_manager.get_character_mut(guid)?;
     let character_id = guid.guid() as u32;
 
-    let Some(slot_id) = character.try_add_item_to_backpack(item_id, character_id, &client.connection_sender).await else {
+    let Some(_slot_id) = character
+        .try_add_item_to_backpack(item_id, character_id, &client.connection_sender, Some(&realm_db))
+        .await
+    else {
         return Ok(());
     };
-
-    let _ = realm_db.insert_character_item(character_id, slot_id, item_id).await;
 
     send_system_message(client_manager, character_manager, client_id, &format!("Added item {}", item_id)).await?;
     Ok(())

--- a/world_server/src/packet_handler.rs
+++ b/world_server/src/packet_handler.rs
@@ -183,7 +183,7 @@ impl PacketHandler {
             ClientOpcodeMessage::CMSG_SET_ACTION_BUTTON(data) => {
                 handle_cmsg_set_action_button(client_manager, character_manager, packet.client_id, data).await
             }
-            _ => bail!("Unhandled opcode"),
+            _ => bail!("Unhandled packet opcode: {:?}", packet.payload),
         }
     }
 }


### PR DESCRIPTION
**Changes:**
- Encapsulated persistence of item slot changes to DB
- Send `SMSG_UPDATE_OBJECT` to client when adding/moving items and rebuild item GUID
- Initial character load logic to use bulk object update